### PR TITLE
Ignore case when checking for OL/WL features

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
@@ -602,8 +602,27 @@ public abstract class InstallFeatureUtil {
      * @throws PluginExecutionException if any of the downloaded JSONs could not be found
      */
     private boolean isOnlyLibertyFeatures(List<String> featuresToInstall) throws PluginExecutionException {
-        boolean result = getLibertyFeatureSet(downloadedJsons).containsAll(featuresToInstall);
+        boolean result = containsIgnoreCase(getLibertyFeatureSet(downloadedJsons), featuresToInstall);
         debug("Is installing only Open or WebSphere Liberty features? " + result);
+        return result;
+    }
+    
+    /**
+     * Returns whether the reference collection contains all of the strings in the target collection, ignoring case.
+     * 
+     * @param reference The reference collection
+     * @param target The target collection
+     * @return true if reference contains all Strings from target, ignoring case
+     */
+    public static boolean containsIgnoreCase(Collection<String> reference, Collection<String> target) {
+        return toLowerCase(reference).containsAll(toLowerCase(target));
+    }
+
+    private static Set<String> toLowerCase(Collection<String> strings) {
+        Set<String> result = new HashSet<String>(strings.size());
+        for (String s : strings) {
+            result.add(s.toLowerCase());
+        }
         return result;
     }
     

--- a/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilTest.java
+++ b/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilTest.java
@@ -18,6 +18,7 @@ package net.wasdev.wlp.common.plugins.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -209,6 +210,34 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         assertTrue("Feature set " + featuresString + " does not contain expected Open Liberty feature appClientSupport-1.0", features.contains("appClientSupport-1.0"));
         assertTrue("Feature set " + featuresString + " does not contain expected WebSphere Liberty feature adminCenter-1.0", features.contains("adminCenter-1.0"));
         assertTrue("Feature set " + featuresString + " does not contain expected WebSphere Liberty feature com.ibm.websphere.appserver.adminCenter.collectiveController-1.0", features.contains("com.ibm.websphere.appserver.adminCenter.collectiveController-1.0"));
+    }
+    
+    @Test
+    public void testContainsIgnoreCase() throws Exception {
+        List<String> reference = new ArrayList<String>();
+        reference.add("featureNameA");
+        reference.add("featureNameB");
+        reference.add("featureNameC");
+        
+        List<String> target = new ArrayList<String>();
+        target.add("featureNameA");
+        target.add("FEATURENAMEB");
+        assertTrue("Collection " + reference + " should contain all of the elements from " + target + " ignoring case", InstallFeatureUtil.containsIgnoreCase(reference, target));
+
+        target = new ArrayList<String>();
+        target.add("featurenamec");
+        assertTrue("Collection " + reference + " should contain all of the elements from " + target + " ignoring case", InstallFeatureUtil.containsIgnoreCase(reference, target));
+
+        target = new ArrayList<String>();
+        target.add("feature");
+        assertFalse("Collection " + reference + " should not contain all of the elements from " + target + " ignoring case", InstallFeatureUtil.containsIgnoreCase(reference, target));
+
+        target = new ArrayList<String>();
+        target.add("featureNameA");
+        target.add("featureNameB");
+        target.add("featureNameC");
+        target.add("other");
+        assertFalse("Collection " + reference + " should not contain all of the elements from " + target + " ignoring case", InstallFeatureUtil.containsIgnoreCase(reference, target));
     }
 
 }


### PR DESCRIPTION
If a feature is specified in lowercase for installation, `InstallFeatureUtil` should use case insensitive string matching when checking if it belongs to Open/WebSphere Liberty, so that it will find the feature and allow `acceptLicense` parameter to be skipped.