### PR TITLE
server.xml in temp dir fix

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
@@ -793,7 +793,7 @@ public abstract class DevUtil {
                         } else if (directory.startsWith(configPath)) { // config files
                             if (fileChanged.exists() && (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
                                     || event.kind() == StandardWatchEventKinds.ENTRY_CREATE)) {
-                                copyConfigFolder(fileChanged, this.configDirectory, "server.xml");
+                                copyConfigFolder(fileChanged, this.configDirectory, null);
                                 copyFile(fileChanged, this.configDirectory, serverDirectory, null);
                                 runTestThread(true, executor, numApplicationUpdatedMessages, true, false);
 


### PR DESCRIPTION
If a file in config directory is modified and is not server.xml, don't rename it to server.xml.