### PR TITLE
Skip usr features in server.xml

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -215,7 +215,7 @@ public abstract class ServerFeatureUtil {
      *            The featureManager node
      * @return Set of trimmed lowercase feature names
      */
-    private static Set<String> parseFeatureManagerNode(Element node) {
+    private Set<String> parseFeatureManagerNode(Element node) {
         Set<String> result = new HashSet<String>();
         NodeList features = node.getElementsByTagName("feature");
         if (features != null) {
@@ -223,8 +223,7 @@ public abstract class ServerFeatureUtil {
                 String content = features.item(j).getTextContent();
                 if (content != null) {
                     if (content.contains(":")) {
-                        String[] split = content.split(":", 2);
-                        result.add(split[1].trim().toLowerCase());
+                        debug("The feature " + content + " in the server.xml file is a user feature and its installation will be skipped.");
                     } else {
                         result.add(content.trim().toLowerCase());
                     }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -519,8 +519,6 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         copyAsName("server_user_features.xml", "server.xml");
 
         Set<String> expected = new HashSet<String>();
-        expected.add("feature1");
-        expected.add("feature2");
         expected.add("feature3");
 
         verifyServerFeatures(expected);


### PR DESCRIPTION
Currently the `install-feature` goal does not support installing user features from the server.xml that are named with `<prefix>:`.  Instead, it should skip them.

Fix for https://github.com/OpenLiberty/ci.maven/issues/537