### PR TITLE
Get debug environment variables for server startup task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
-            <version>1.9.1</version>
+            <version>1.9.2-SNAPSHOT</version>
         </dependency>
 	</dependencies>
 </project>

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -53,6 +53,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
@@ -548,7 +549,7 @@ public abstract class DevUtil {
         }
         return null;
     }
-    
+
     public void cleanUpServerEnv() {
         // clean up server.env file
         File serverEnvFile;
@@ -572,7 +573,7 @@ public abstract class DevUtil {
             error("Could not retrieve server.env: " + e.getMessage());
         }
     }
-    
+
     public void cleanUpTempConfig() {
         if (this.tempConfigPath != null){
             File tempConfig = this.tempConfigPath.toFile();
@@ -613,6 +614,18 @@ public abstract class DevUtil {
                 stopServer();
             }
         });
+    }
+
+    /**
+     * Gets a map of the environment variables to set for debug mode.
+     * 
+     * @param libertyDebugPort the debug port to use
+     */
+    public Map<String, String> getDebugEnvironmentVariables(int libertyDebugPort) throws IOException {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("WLP_DEBUG_SUSPEND", "n");
+        map.put("WLP_DEBUG_ADDRESS", String.valueOf(findAvailablePort(libertyDebugPort)));
+        return map;
     }
 
     public void enableServerDebug(int libertyDebugPort) throws IOException {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -131,6 +131,7 @@ public class DevUtilTest extends BaseDevUtilTest {
 
         // bind to it
         ServerSocket serverSocket = null;
+        ServerSocket serverSocket2 = null;
         try {
             serverSocket = new ServerSocket();
             serverSocket.setReuseAddress(false);
@@ -139,8 +140,29 @@ public class DevUtilTest extends BaseDevUtilTest {
             // previous port is bound, so calling findAvailablePort again should get another port
             int availablePort2 = util.findAvailablePort(preferredPort);
             assertNotEquals(availablePort, availablePort2);
-        } finally {
+
+            // unbind the port
             serverSocket.close();
+
+            // calling findAvailablePort again should return the previous port which was cached, even though the preferred port is available
+            int availablePort3 = util.findAvailablePort(preferredPort);
+            assertEquals(availablePort2, availablePort3);
+
+            // bind to the previous port
+            serverSocket2 = new ServerSocket();
+            serverSocket2.setReuseAddress(false);
+            serverSocket2.bind(new InetSocketAddress(InetAddress.getByName(null), availablePort2), 1);
+
+            // previous port is also bound, so calling findAvailablePort again should get another port
+            int availablePort4 = util.findAvailablePort(preferredPort);
+            assertNotEquals(availablePort2, availablePort4);
+        } finally {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+            if (serverSocket2 != null) {
+                serverSocket2.close();
+            }
         }
     }
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -30,6 +30,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -150,6 +151,14 @@ public class DevUtilTest extends BaseDevUtilTest {
         } finally {
             serverSocket.close();
         }
+    }
+
+    @Test
+    public void testGetDebugEnvironmentVariables() throws Exception {
+        int port = getRandomPort();
+        Map<String, String> map = util.getDebugEnvironmentVariables(port);
+        assertEquals("n", map.get("WLP_DEBUG_SUSPEND"));
+        assertEquals(String.valueOf(port), map.get("WLP_DEBUG_ADDRESS"));
     }
     
     @Test


### PR DESCRIPTION
Get debug environment variables for passing to the server startup ant task, in addition to creating server.env.  The task's environment variables will be the default, and the ones in server.env will override them (but they should always be the same).  The port should be consistent between them.

This is needed as part of https://github.com/OpenLiberty/ci.maven/issues/580 so that dev mode (with debug mode) will work on Windows on previous Liberty releases even if the server.bat was not handling server.env properly.
