### PR TITLE
redeploy app when classes dir is created

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
@@ -1485,7 +1486,7 @@ public abstract class DevUtil {
                 if (!classesDir.mkdirs()) {
                     throw new PluginExecutionException("The classes output directory " + classesDir.getAbsolutePath()
                             + " does not exist and cannot be created.");
-                } else {
+                } else if (classesDir.exists() && Objects.equals(classesDir.getCanonicalFile(), outputDirectory.getCanonicalFile())) {
                     // redeploy application when class directory has been created
                     redeployApp();
                 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1116,12 +1116,12 @@ public abstract class DevUtil {
                                     || event.kind() == StandardWatchEventKinds.ENTRY_CREATE)) {
                                 copyConfigFolder(fileChanged, configDirectory, null);
                                 copyFile(fileChanged, configDirectory, serverDirectory, null);
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                                    redeployApp();
+                                }
                                 if (fileChanged.getName().equals("server.env")) {
                                     // re-enable debug variables in server.env
                                     enableServerDebug(false);
-                                }
-                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
-                                    redeployApp();
                                 }
                                 runTestThread(true, executor, numApplicationUpdatedMessages, true, false);
                             } else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -216,6 +216,11 @@ public abstract class DevUtil {
      * @throws Exception if there was an error copying/creating config files
      */
     public abstract ServerTask getServerTask() throws Exception;
+    
+    /**
+     * Redeploy the application
+     */
+    public abstract void redeployApp() throws Exception;
 
     private File serverDirectory;
     private File sourceDirectory;
@@ -1471,9 +1476,14 @@ public abstract class DevUtil {
             
             // source root is src/main/java or src/test/java
             File classesDir = tests ? testOutputDirectory : outputDirectory;
-
-            if (!classesDir.exists() && !classesDir.mkdirs()) {
-                throw new PluginExecutionException("The classes output directory " + classesDir.getAbsolutePath() + " does not exist and cannot be created.");
+            if (!classesDir.exists()) {
+                if (!classesDir.mkdirs()) {
+                    throw new PluginExecutionException("The classes output directory " + classesDir.getAbsolutePath()
+                            + " does not exist and cannot be created.");
+                } else {
+                    // redeploy application when class directory has been created
+                    redeployApp();
+                }
             }
 
             List<String> optionList = new ArrayList<>();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -221,7 +221,7 @@ public abstract class DevUtil {
     /**
      * Redeploy the application
      */
-    public abstract void redeployApp() throws Exception;
+    public abstract void redeployApp() throws PluginExecutionException;
 
     private File serverDirectory;
     private File sourceDirectory;

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1021,7 +1021,7 @@ public abstract class DevUtil {
                         registerAll(configPath, watcher);
                         debug("Registering configuration directory: " + this.configDirectory);
                     } else {
-                        info("The server configuration directory " + configDirectory + " has been added. Restart liberty:dev mode for it to take effect.");
+                        warn("The server configuration directory " + configDirectory + " has been added. Restart liberty:dev mode for it to take effect.");
                     }
                 }
                 
@@ -1029,7 +1029,7 @@ public abstract class DevUtil {
                 if (!serverXmlFileRegistered && serverXmlFile != null && serverXmlFile.exists()){
                     serverXmlFileRegistered = true;
                     debug("Server configuration file has been added: " + serverXmlFile);
-                    info("The server configuration file " + serverXmlFile + " has been added. Restart liberty:dev mode for it to take effect.");
+                    warn("The server configuration file " + serverXmlFile + " has been added. Restart liberty:dev mode for it to take effect.");
                 }
                 
                 // check if resourceDirectory has been added
@@ -1119,6 +1119,9 @@ public abstract class DevUtil {
                                     // re-enable debug variables in server.env
                                     enableServerDebug(false);
                                 }
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                                    redeployApp();
+                                }
                                 runTestThread(true, executor, numApplicationUpdatedMessages, true, false);
                             } else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
                                 info("Config file deleted: " + fileChanged.getName());
@@ -1136,7 +1139,9 @@ public abstract class DevUtil {
                                 copyConfigFolder(fileChanged, serverXmlFileParent, "server.xml");
                                 copyFile(fileChanged, serverXmlFileParent, serverDirectory,
                                         "server.xml");
-
+                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                                    redeployApp();
+                                }
                                 runTestThread(true, executor, numApplicationUpdatedMessages, true, false);
 
                             } else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -149,7 +149,7 @@ public class BaseDevUtilTest {
         }
 
         @Override
-        public void redeployApp() throws Exception {
+        public void redeployApp() throws PluginExecutionException {
             // not needed for tests
         }
         

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -147,6 +147,11 @@ public class BaseDevUtilTest {
         public void runIntegrationTests() throws PluginScenarioException, PluginExecutionException {
             // not needed for tests
         }
+
+        @Override
+        public void redeployApp() throws Exception {
+            // not needed for tests
+        }
         
     }
     


### PR DESCRIPTION
partial fix for [issue 569](https://github.com/OpenLiberty/ci.maven/issues/569)

Redeploy application if the classes directory must be created (first java class file is created).