### PR TITLE
Check for server start message, log error for port conflict

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -487,9 +487,7 @@ public abstract class DevUtil {
             // Check for port already in use error
             String portError = serverTask.findStringInFile(PORT_IN_USE_MESSAGE_PREFIX, messagesLogFile);
             if (portError != null) {
-                setDevStop(true);
-                stopServer();
-                throw new PluginExecutionException(portError.split(PORT_IN_USE_MESSAGE_PREFIX)[1]);
+                error(portError.split(PORT_IN_USE_MESSAGE_PREFIX)[1]);
             }
             
             // Parse hostname, http, https ports for integration tests to use

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -81,6 +81,7 @@ import org.apache.commons.io.FileUtils;
  */
 public abstract class DevUtil {
 
+    private static final String START_SERVER_MESSAGE_PREFIX = "CWWKF0011I:";
     private static final String START_APP_MESSAGE_REGEXP = "CWWKZ0001I.*";
     private static final String UPDATED_APP_MESSAGE_REGEXP = "CWWKZ0003I.*";
     private static final String PORT_IN_USE_MESSAGE_PREFIX = "CWWKO0221E:";
@@ -414,12 +415,6 @@ public abstract class DevUtil {
             String logsDirectory = serverTask.getOutputDir() + "/" + serverTask.getServerName() + "/logs";
             File messagesLogFile = new File(logsDirectory + "/messages.log");
 
-            // Set server start timeout
-            if (serverStartTimeout < 0) {
-                serverStartTimeout = 30;
-            }
-            serverTask.setTimeout(Long.toString(serverStartTimeout * 1000));
-
             // Watch logs directory if it already exists
             WatchService watchService = FileSystems.getDefault().newWatchService();
             boolean logsExist = new File(logsDirectory).isDirectory();
@@ -467,6 +462,21 @@ public abstract class DevUtil {
                         break;
                     }
                 }
+            }
+
+            // Set server start timeout
+            if (serverStartTimeout < 0) {
+                serverStartTimeout = 30;
+            }
+            long serverStartTimeoutMillis = serverStartTimeout * 1000;
+
+            // Wait for the server started message in messages.log
+            String startMessage = serverTask.waitForStringInLog(START_SERVER_MESSAGE_PREFIX, serverStartTimeoutMillis, messagesLogFile);
+            if (startMessage == null) {
+                setDevStop(true);
+                stopServer();
+                throw new PluginExecutionException("Unable to verify if the server was started after " + serverStartTimeoutMillis
+                        + " seconds.  Consider increasing the serverStartTimeout value if this continues to occur.");
             }
 
             // Check for port already in use error

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -410,7 +410,12 @@ public abstract class DevUtil {
      */
     public void startServer(long serverStartTimeout) throws PluginExecutionException {
         try {
-            final ServerTask serverTask = getServerTask();
+            final ServerTask serverTask;
+            try {
+                serverTask = getServerTask();
+            } catch (Exception e) {
+                throw new PluginExecutionException("An error occurred while starting the server: " + e.getMessage(), e);
+            }
 
             String logsDirectory = serverTask.getOutputDir() + "/" + serverTask.getServerName() + "/logs";
             File messagesLogFile = new File(logsDirectory + "/messages.log");
@@ -490,8 +495,8 @@ public abstract class DevUtil {
             // Parse hostname, http, https ports for integration tests to use
             parseHostNameAndPorts(serverTask, messagesLogFile);
 
-        } catch (Exception e) {
-            debug("Error starting server", e);
+        } catch (IOException | InterruptedException e) {
+            throw new PluginExecutionException("An error occurred while starting the server: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -438,11 +438,10 @@ public abstract class DevUtil {
                 public void run() {
                     try {
                         serverTask.execute();
-                    } catch (Exception e) {
-                        long serverStartTimeout = Long.parseLong(serverTask.getTimeout());
-                        debug("Error starting server after " + (serverStartTimeout / 1000)
-                                + " seconds. Consider increasing the serverStartTimeout value if this continues to occur.",
-                                e);
+                    } catch (RuntimeException e) {
+                        // If a runtime exception occurred in the server task, log and rethrow
+                        error("An error occurred while starting the server: " + e.getMessage(), e);
+                        throw e;
                     }
                 }
 


### PR DESCRIPTION
- Check for server start message
- Throw exceptions if they occur server start instead of logging as debug
- Do not exit dev mode if there is a port conflict

Fixes https://github.com/OpenLiberty/ci.maven/issues/652
Fixes https://github.com/OpenLiberty/ci.maven/issues/653