### PR TITLE
Add apiTypeVisibility to LibertyManagedProperty

### DIFF
--- a/src/main/java/io/openliberty/tools/common/arquillian/objects/LibertyManagedObject.java
+++ b/src/main/java/io/openliberty/tools/common/arquillian/objects/LibertyManagedObject.java
@@ -44,6 +44,7 @@ public class LibertyManagedObject {
         appDeployTimeout, 
         appUndeployTimeout, 
         sharedLib, 
+        apiTypeVisibility,
         deployType, 
         javaVmArguments, 
         addLocalConnector, 


### PR DESCRIPTION
Allow setting the property "apiTypeVisibility" in liberty-maven-plugin configuration. See also https://github.com/OpenLiberty/ci.maven/issues/523