### PR TITLE
Enable using build recompiler

### DIFF
--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -35,7 +35,7 @@ public class BaseDevUtilTest {
 
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
-            super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true);
+            super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true, false);
         }
 
         @Override


### PR DESCRIPTION
Enables dev mode in Gradle to use the Gradle compiler for recompiling.  Gradle tests depend on compile, so by using Gradle to compile during changes and then run tests (which invokes compile again), it will not recompile the second time.  Also, Gradle does not appear to have the conflict with the Java LS described in https://github.com/OpenLiberty/ci.maven/issues/686.