### PR TITLE
warn user to restart if resource dir is deleted

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1136,13 +1136,13 @@ public abstract class DevUtil {
                 }
                 
                 // check if resourceDirectory has been added
-                for (File resourceDir : resourceDirs){
-                    if (!resourceMap.get(resourceDir)) {
-                        if (resourceDir.exists()) {
-                            registerAll(resourceDir.getCanonicalFile().toPath(), watcher);
-                            resourceMap.put(resourceDir, true);
-                        }
-                    } else {
+                for (File resourceDir : resourceDirs) {
+                    if (!resourceMap.get(resourceDir) && resourceDir.exists()) {
+                        // added resource directory
+                        registerAll(resourceDir.getCanonicalFile().toPath(), watcher);
+                        resourceMap.put(resourceDir, true);
+                    } else if (resourceMap.get(resourceDir) && !resourceDir.exists()) {
+                        // deleted resource directory
                         warn("The resource directory " + resourceDir
                                 + " was deleted.  Restart liberty:dev mode for it to take effect.");
                         resourceMap.put(resourceDir, false);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1142,6 +1142,9 @@ public abstract class DevUtil {
                             registerAll(resourceDir.getCanonicalFile().toPath(), watcher);
                             resourceMap.put(resourceDir, true);
                         }
+                    } else if (resourceMap.get(resourceDir) && !resourceDir.exists()) {
+                        warn("The resource directory " + resourceDir + "was deleted.  Restart liberty:dev mode for it to take effect.");
+                        resourceMap.put(resourceDir, false);
                     }
                 }
 
@@ -1255,7 +1258,6 @@ public abstract class DevUtil {
                             }
                         } else if (resourceParent != null && directory.startsWith(resourceParent.getCanonicalFile().toPath())) { // resources
                             debug("Resource dir: " + resourceParent.toString());
-                            debug("File within resource directory");
                             if (fileChanged.exists() && (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
                                     || event.kind() == StandardWatchEventKinds.ENTRY_CREATE)) {
                                 copyFile(fileChanged, resourceParent, outputDirectory, null);
@@ -1290,7 +1292,7 @@ public abstract class DevUtil {
                     // reset the key
                     boolean valid = wk.reset();
                     if (!valid) {
-                        debug("WatchService key has been unregistered");
+                        debug("WatchService key has been unregistered for " + directory);
                     }
                 } catch (InterruptedException | NullPointerException e) {
                     // do nothing let loop continue

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1142,8 +1142,9 @@ public abstract class DevUtil {
                             registerAll(resourceDir.getCanonicalFile().toPath(), watcher);
                             resourceMap.put(resourceDir, true);
                         }
-                    } else if (resourceMap.get(resourceDir) && !resourceDir.exists()) {
-                        warn("The resource directory " + resourceDir + "was deleted.  Restart liberty:dev mode for it to take effect.");
+                    } else {
+                        warn("The resource directory " + resourceDir
+                                + " was deleted.  Restart liberty:dev mode for it to take effect.");
                         resourceMap.put(resourceDir, false);
                     }
                 }


### PR DESCRIPTION
Decided to warn user to restart dev mode when a resource directory is deleted.  Tracking the files within each resource directory to know which to delete upon deletion of the directory is too expensive.

Fixes https://github.com/OpenLiberty/ci.maven/issues/700