### PR TITLE
Exit dev mode without force stopping JVM

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -702,23 +702,27 @@ public abstract class DevUtil {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                debug("Inside Shutdown Hook, shutting down server");
-                
-                setDevStop(true);
-                cleanUpTempConfig();
-                cleanUpServerEnv();
-
-                if (hotkeyReader != null) {
-                    hotkeyReader.shutdown();
-                }
-
-                // shutdown tests
-                executor.shutdown();
-
-                // stopping server
-                stopServer();
+                shutdownHook(executor);
             }
         });
+    }
+
+    private void shutdownHook(final ThreadPoolExecutor executor) {
+        debug("Inside Shutdown Hook, shutting down server");
+        
+        setDevStop(true);
+        cleanUpTempConfig();
+        cleanUpServerEnv();
+
+        if (hotkeyReader != null) {
+            hotkeyReader.shutdown();
+        }
+
+        // shutdown tests
+        executor.shutdown();
+
+        // stopping server
+        stopServer();
     }
 
     /**
@@ -925,7 +929,7 @@ public abstract class DevUtil {
                     if (line != null && (line.trim().equalsIgnoreCase("q") || line.trim().equalsIgnoreCase("quit")
                             || line.trim().equalsIgnoreCase("exit"))) {
                         debug("Detected exit command");
-                        System.exit(0);
+                        shutdownHook(executor);
                     } else {
                         debug("Detected Enter key. Running tests...");
                         runTestThread(false, executor, -1, false, true);
@@ -1032,8 +1036,14 @@ public abstract class DevUtil {
 
             while (true) {
                 // stop dev mode if the server has been stopped by another process
-                if (serverThread.getState().equals(Thread.State.TERMINATED) && (this.devStop.get() == false)) {
-                    throw new PluginScenarioException("The server has stopped. Exiting dev mode.");
+                if (serverThread.getState().equals(Thread.State.TERMINATED)) {
+                    if (!this.devStop.get()) {
+                        // server was stopped outside of dev mode
+                        throw new PluginScenarioException("The server has stopped. Exiting dev mode.");
+                    } else {
+                        // server was stopped by dev mode
+                        throw new PluginScenarioException("Exiting dev mode.");
+                    }
                 }
 
                 // process java source files if no changes detected after the compile wait time

--- a/src/main/java/io/openliberty/tools/common/plugins/util/PluginScenarioException.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/PluginScenarioException.java
@@ -24,6 +24,9 @@ public class PluginScenarioException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    public PluginScenarioException() {
+    }
+
     public PluginScenarioException(String message) {
         super(message);
     }


### PR DESCRIPTION
When user types "exit", instead of calling `System.exit(0)`, it should call the shutdown hook to stop dev mode and then just return gracefully from the task.  This is needed for Gradle since Gradle has a long running daemon that is not supposed to exit.

Part of https://github.com/OpenLiberty/ci.gradle/issues/378