### PR TITLE
Added flag for gradle and changed wording from IT to tests

### DIFF
--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -35,7 +35,7 @@ public class BaseDevUtilTest {
 
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
-            super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true, false);
+            super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true, false, false);
         }
 
         @Override


### PR DESCRIPTION
Partial fix for https://github.com/OpenLiberty/ci.gradle/issues/382

Add a flag to identify if `DevUtil` was called by a Gradle process or not.  If triggered by a Gradle process, skip unit tests and rename integration tests simply to "tests".