### PR TITLE
Fix null pointer on empty bootstrap.properties or jvm.options

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1747,7 +1747,7 @@ public abstract class DevUtil {
         try (FileReader fileReader = new FileReader(targetFile);
                 BufferedReader bufferedReader = new BufferedReader(fileReader)) {
             String line = bufferedReader.readLine();
-            return line.matches(GENERATED_HEADER_REGEX);
+            return line == null ? false : line.matches(GENERATED_HEADER_REGEX);
         } catch (IOException e) {
             // If the target file could not be read, assume it was not a generated file
             debug("Could not read the target file " + targetFile + ". It will be replaced by the contents of "


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/779

With this fix, adding an empty bootstrap.properties or jvm.options (through either command line or VS Code) causes the server to restart and pick up the changes, and also picks up further changes.