### PR TITLE
First draft of container support.

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
@@ -26,6 +26,12 @@ import org.w3c.dom.Element;
 
 public class LooseConfigData extends XmlDocument {
     
+    private String projectRoot = null;
+
+    public void setProjectRoot(String root) {
+        projectRoot = root;
+    }
+
     public LooseConfigData() throws ParserConfigurationException {
         createDocument("archive");
     }
@@ -98,9 +104,19 @@ public class LooseConfigData extends XmlDocument {
     }
     
     private void addElement(Element parent, Element child, File src, String target) throws DOMException, IOException {
-        child.setAttribute("sourceOnDisk", src.getCanonicalPath());
+        String name = src.getCanonicalPath();
+        if (projectRoot != null && name.startsWith(projectRoot)) {
+            child.setAttribute("sourceOnDisk", "/devmode" + name.substring(projectRoot.length()));
+        } else {
+            child.setAttribute("sourceOnDisk", src.getCanonicalPath());
+        }
         addElement(parent, child, target);
     }
+    
+    // private void addElement(Element parent, Element child, File src, String target) throws DOMException, IOException {
+    //     child.setAttribute("sourceOnDisk", src.getCanonicalPath());
+    //     addElement(parent, child, target);
+    // }
     
     private void addElement(Element parent, Element child, String target) {
         child.setAttribute("targetInArchive", target);


### PR DESCRIPTION
If you're testing and you have trouble starting a container because port 9443 is in use there is a hidden debug option -D9443 not to generate the option to publish that port. 
Sample test command: mvn -X liberty:dev -Dcontainer -DdockerRun="-v /tmp:/tmp2" -D9443
This sample demonstrates the dockerRun option.