### PR TITLE
Add default compiler options for debugging

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -106,6 +106,8 @@ public abstract class DevUtil {
             // intellij
             "___jb_tmp___", "___jb_old___" };
 
+    private static final String[] DEFAULT_COMPILER_OPTIONS = new String[] { "-g", "-parameters" };
+
     /**
      * Log debug
      * 
@@ -2119,7 +2121,7 @@ public abstract class DevUtil {
                     }
                 }
 
-                List<String> optionList = new ArrayList<>();
+                List<String> optionList = new ArrayList<>(Arrays.asList(DEFAULT_COMPILER_OPTIONS));
                 List<File> outputDirs = new ArrayList<File>();
 
                 if (tests) {


### PR DESCRIPTION
For dev mode, if compiler options are not specified in the build file, use "-g" to generate all debugging information and "-parameters" to allow reflection access to parameter names.  (We should also handle additional options from the build file, but that should be addressed in a separate PR.)

This partially addresses https://github.com/OpenLiberty/ci.maven/issues/746