### PR TITLE
Handle container checks

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -502,7 +502,7 @@ public abstract class DevUtil {
      */
     private File getMessagesLogFile(ServerTask serverTask) {
         File logFile;
-        if (serverTask != null) {
+        if (!container && serverTask != null) {
             logFile = serverTask.getLogFile();
         } else {
             logFile = new File(serverDirectory, "logs/messages.log");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -495,17 +495,17 @@ public abstract class DevUtil {
     }
 
     /**
-     * Get the log file from server task or server directory.
+     * Get the log file from server directory if using container, or from server task otherwise.
      * 
-     * @param serverTask the server task, can be null
+     * @param serverTask the server task
      * @return the messages log file for the server
      */
     private File getMessagesLogFile(ServerTask serverTask) {
         File logFile;
-        if (!container && serverTask != null) {
-            logFile = serverTask.getLogFile();
-        } else {
+        if (container) {
             logFile = new File(serverDirectory, "logs/messages.log");
+        } else {
+            logFile = serverTask.getLogFile();           
         }
         return logFile;
     }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1039,10 +1039,7 @@ public abstract class DevUtil {
             }
         }
         libertyCreate();
-        if (!container) {
-            // local dev mode can't install feature on containerized runtime, unless we exec into the container
-            libertyInstallFeature();
-        }
+        libertyInstallFeature();
         libertyDeploy();
         startServer();
         setDevStop(false);


### PR DESCRIPTION
- libertyInstallFeature() is abstract, so check for container option and skip installing features (for now) in Maven/Gradle instead of here.
- getMessagesLogFile() should avoid using serverTask to get the log file in container mode, the ServerTask did not have its initTask() called yet.