### PR TITLE
Set up file permissions on Linux to start a container as a non-root user

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -948,12 +948,11 @@ public abstract class DevUtil {
             String os = System.getProperty("os.name");
             String id = System.getProperty("user.name");
             if (os != null && os.equalsIgnoreCase("linux")) {
-                // Allow the container server to read the config files e.g. server.xml
+                // Allow the container server to read the config files like server.xml
                 runCmd(false, "chmod -R o+r " + serverDirectory);
                 // Allow the container server to read directories like apps and dropins
-                runCmd("chmod -R o+x " + serverDirectory + "/apps " +
-                    serverDirectory + "/dropins " +
-                    serverDirectory + "/configDropins");
+                runCmd("find " + serverDirectory +
+                    " -type d -not -name logs -not -name workarea -exec chmod o+x {} ;");
                 // Allow the server to write to the log files.
                 runCmd("mkdir -p " + serverDirectory + "/logs");
                 if (id != null && id.equalsIgnoreCase("root")) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -947,14 +947,22 @@ public abstract class DevUtil {
             // Set up permissions on Linux
             String os = System.getProperty("os.name");
             String id = System.getProperty("user.name");
-            if (os != null && os.equalsIgnoreCase("linux") &&
-                id != null && id.equalsIgnoreCase("root")) {
+            if (os != null && os.equalsIgnoreCase("linux")) {
                 // Allow the container server to read the config files e.g. server.xml
-                runCMD("chmod -R o+r " + serverDirectory);
+                runCmd(false, "chmod -R o+r " + serverDirectory);
+                // Allow the container server to read directories like apps and dropins
+                runCmd("chmod -R o+x " + serverDirectory + "/apps " +
+                    serverDirectory + "/dropins " +
+                    serverDirectory + "/configDropins");
                 // Allow the server to write to the log files.
-                runCMD("mkdir -p " + serverDirectory + "/logs");
-                runCMD("chown -R 1001:0 " + serverDirectory + "/logs"); // in case it is new
-                runCMD("chmod -R u+rw " + serverDirectory + "/logs"); // in case it is old
+                runCmd("mkdir -p " + serverDirectory + "/logs");
+                if (id != null && id.equalsIgnoreCase("root")) {
+                    runCmd("chown -R 1001:0 " + serverDirectory + "/logs"); // in case it is new
+                    runCmd("chmod -R u+rw " + serverDirectory + "/logs"); // in case it is old
+                } else {
+                    // Set gid bit so that log file group id is same as current id.
+                    runCmd(false, "chmod -R go+rws " + serverDirectory + "/logs");
+                }
             }
 
             String startContainerCommand = getContainerCommand();
@@ -989,11 +997,19 @@ public abstract class DevUtil {
         }
     }
 
-    private void runCMD(String cmd) throws IOException, InterruptedException {
+    private void runCmd(String cmd) throws IOException, InterruptedException {
+        runCmd(true, cmd);
+    }
+
+    private void runCmd(boolean report, String cmd) throws IOException, InterruptedException {
         Process p = Runtime.getRuntime().exec(cmd);
         p.waitFor(5, TimeUnit.SECONDS);
         if (p.exitValue() != 0) {
-            error("Error running command:" + cmd + ", return value=" + p.exitValue());
+            if (report) {
+                error("Error running command:" + cmd + ", return value=" + p.exitValue());
+            } else {
+                debug("Error running command:" + cmd + ", return value=" + p.exitValue());
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes when you are a non-root user you have permission to modify a file but sometimes the file was created by the docker container. Thus you can get errors trying to modify a file the second time you run dev mode. Thus some error reporting is removed and only available in debug mode. The alternative would be to loop through all the files and not touch files that could not be changed just for the purpose of not generating an error message. 

Fixes https://github.com/OpenLiberty/ci.maven/issues/888