### PR TITLE
Only mount the file to the container if it exists.

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1171,7 +1171,12 @@ public abstract class DevUtil {
 
         // mount all files from COPY commands in the Dockerfile to allow for hot deployment
         for (int i=0; i < srcMount.size(); i++) {
-            command.append(" -v " + srcMount.get(i) + ":" + destMount.get(i));
+            if (new File(srcMount.get(i)).exists()) { // only Files are in this list
+                command.append(" -v " + srcMount.get(i) + ":" + destMount.get(i));
+            } else {
+                error("A file referenced by the Dockerfile is not found: " + srcMount.get(i) +
+                    ". Update the Dockerfile or ensure the file is in the correct location.");
+            }
         }
 
         command.append(" --name " + DEVMODE_CONTAINER_NAME);


### PR DESCRIPTION
On Linux if the file is missing Docker assumes you want to mount a directory on a directory so it creates the missing directory on the host and the container as required. In the case of our Dockerfile copies like server.xml or bootstrap.properties we need to check if they exist before mounting. Once we support to copy a directory of files in Dockerfile we may need to update this code. 
Fixes https://github.com/OpenLiberty/ci.gradle/issues/519