### PR TITLE
Add --user option to docker run when running on Linux.

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -956,24 +956,9 @@ public abstract class DevUtil {
 
     private void startContainer() {
         try {
-            // Set up permissions on Linux
-            String os = System.getProperty("os.name");
-            String id = System.getProperty("user.name");
-            if (os != null && os.equalsIgnoreCase("linux")) {
-                // Allow the container server to read the config files like server.xml
-                runCmd(false, "chmod -R o+r " + serverDirectory);
-                // Allow the container server to read directories like apps and dropins
-                runCmd("find " + serverDirectory +
-                    " -type d -not -name logs -not -name workarea -exec chmod o+x {} ;");
-                // Allow the server to write to the log files.
+            if (System.getProperty("os.name").equalsIgnoreCase("linux")) {
+                // Allow the server to write to the log files. If we don't create it here docker daemon will create it as root.
                 runCmd("mkdir -p " + serverDirectory + "/logs");
-                if (id != null && id.equalsIgnoreCase("root")) {
-                    runCmd("chown -R 1001:0 " + serverDirectory + "/logs"); // in case it is new
-                    runCmd("chmod -R u+rw " + serverDirectory + "/logs"); // in case it is old
-                } else {
-                    // Set gid bit so that log file group id is same as current id.
-                    runCmd(false, "chmod -R go+rws " + serverDirectory + "/logs");
-                }
             }
 
             info("Starting Docker container...");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1194,7 +1194,7 @@ public abstract class DevUtil {
      * @return the command string to use to start the container
      */
     private String getContainerCommand() {
-        StringBuffer command = new StringBuffer("docker run --rm");
+        StringBuilder command = new StringBuilder("docker run --rm");
         if (httpPort != null) {
             command.append(" -p "+httpPort+":"+httpPort);
         } else {
@@ -1249,7 +1249,7 @@ public abstract class DevUtil {
 
     // Read all the files from the array list.
     private String getCopiedFiles() {
-        StringBuffer param = new StringBuffer("");
+        StringBuilder param = new StringBuilder(256); // estimate of size needed
         for (int i=0; i < srcMount.size(); i++) {
             if (new File(srcMount.get(i)).exists()) { // only Files are in this list
                 param.append(" -v ").append(srcMount.get(i)).append(":").append(destMount.get(i));


### PR DESCRIPTION
On Linux, run the server on the user id of the current user (the developer). This should be valid because Liberty was designed to be installed by root and then run as a non-root user. 
Also refactored the code that adds the dockerfile copied files to the docker run command.
Fixes https://github.com/OpenLiberty/ci.maven/issues/919