### PR TITLE
Add hotkey to restart server, add formatting to dev mode startup messages

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -855,7 +855,7 @@ public abstract class DevUtil {
                         "'. There must be at least two arguments for the COPY command, a source path and a destination path.");
                     }
                     if (line.contains("$")) {
-                        warn("The Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support environment variables in COPY commands.");
+                        warn("The Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support environment variables in COPY commands. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
                         continue;
                     }
                     List<String> srcOrDestArguments = new ArrayList<String>();
@@ -885,7 +885,7 @@ public abstract class DevUtil {
                     List<String> srcArguments = srcOrDestArguments.subList(0, srcOrDestArguments.size() - 1);
                     for (String src : srcArguments) {
                         if (src.contains("*") || src.contains("?")) {
-                            warn("The COPY source " + src + " in the Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support wildcards in the COPY command.");
+                            warn("The COPY source " + src + " in the Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support wildcards in the COPY command. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
                         } else if (isMountableSource(new File(buildContext + "/" + src))) {
                             String srcMountString = buildContext + "/" + src;
                             String destMountString = formatDestMount(dest, new File(buildContext + "/" + src));
@@ -903,7 +903,8 @@ public abstract class DevUtil {
         if (srcMountFile.isDirectory()) {
             warn("Files in the directory " + srcMountFile + " will not be able to be hot deployed to the dev mode container. " +
                 "Dev mode does not currently support hot deployment with directories specified in the COPY command. " + 
-                "To allow files to be hot deployed, specify individual files when using the COPY command in your Dockerfile");
+                "To allow files to be hot deployed, specify individual files when using the COPY command in your Dockerfile. " + 
+                "Otherwise, if you make changes to files in this directory, type 'r' and press Enter to rebuild the Docker image and restart the container.");
             return false;
         } // no need to validate existence of the file, just let the Docker build fail
         return true;

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -313,7 +313,7 @@ public abstract class DevUtil {
     private int dockerBuildTimeout;
     protected List<String> srcMount = new ArrayList<String>();
     protected List<String> destMount = new ArrayList<String>();
-    private boolean printedStartupMessages = false;
+    private boolean printStartupMessages = true;
 
     public DevUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory, File projectDirectory,
             List<File> resourceDirs, boolean hotTests, boolean skipTests, boolean skipUTs, boolean skipITs,
@@ -1697,38 +1697,57 @@ public abstract class DevUtil {
                         inputUnavailable.wait(500);
                     }
                     // the following will be printed only on first startup
-                    if (!printedStartupMessages) {
-                        info("Liberty dev mode has started!");
+                    if (printStartupMessages) {
+                        info(formatAttentionBarrier()); // print barrier header
+                        info(formatAttentionTitle("Liberty dev mode has started!"));
                     }
 
                     if (!inputUnavailable.get()) {
-                        // the following will be printed every time after the tests run
+                        // the following will be printed on startup and every time after the tests run
                         if (hotTests) {
-                            info("Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.");
+                            String message = "Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.";
+                            info(printStartupMessages ? formatAttentionMessage(message) : message);
                         } else {
-                            info("Press the Enter key to run tests on demand.");
+                            String message = "To run tests on demand, press Enter.";
+                            info(printStartupMessages ? formatAttentionMessage(message) : message);
                         }
 
                         // the following will be printed only on first startup
-                        if (!printedStartupMessages) {
+                        if (printStartupMessages) {
                             if (container) {
-                                info("If you need to rebuild the Docker image and restart the container, type 'r' and press the Enter key.");
+                                info(formatAttentionMessage("To rebuild the Docker image and restart the container, type 'r' and press Enter."));
                             } else {
-                                info("If you need to restart the server, type 'r' and press the Enter key.");
+                                info(formatAttentionMessage("To restart the server, type 'r' and press Enter."));
                             }
-                            info("To stop the server and quit dev mode, use Ctrl-C or type 'q' and press the Enter key.");
+                            info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
                         }
                     } else {
                         debug("Cannot read user input, setting hotTests to true.");
-                        info("Tests will run automatically when changes are detected.");
+                        String message = "Tests will run automatically when changes are detected.";
+                        info(printStartupMessages ? formatAttentionMessage(message) : message);
                         hotTests = true;
                     }
-                    printedStartupMessages = true;
+                    if (printStartupMessages) {
+                        info(formatAttentionBarrier()); // print barrier footer
+                        printStartupMessages = false;
+                    }
                 } catch (InterruptedException e) {
                     debug("Interrupted while waiting to determine whether input can be read", e);
                 }
             }
         }
+    }
+
+    private String formatAttentionBarrier() {
+        return "************************************************************************";
+    }
+
+    private String formatAttentionTitle(String message) {
+        return "*    " + message;
+    }
+
+    private String formatAttentionMessage(String message) {
+        return "*        " + message;
     }
 
     private class HotkeyReader implements Runnable {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -313,6 +313,7 @@ public abstract class DevUtil {
     private int dockerBuildTimeout;
     protected List<String> srcMount = new ArrayList<String>();
     protected List<String> destMount = new ArrayList<String>();
+    private boolean printedStartupMessages = false;
 
     public DevUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory, File projectDirectory,
             List<File> resourceDirs, boolean hotTests, boolean skipTests, boolean skipUTs, boolean skipITs,
@@ -1695,10 +1696,27 @@ public abstract class DevUtil {
                         inputUnavailable.wait(500);
                     }
                     if (!inputUnavailable.get()) {
+                        // the following will be printed only on first startup
+                        if (!printedStartupMessages) {
+                            info("Liberty dev mode has started!");
+                        }
+
+                        // the following will be printed every time after the tests run
                         if (hotTests) {
                             info("Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.");
                         } else {
-                            info("Press the Enter key to run tests on demand. To stop the server and quit dev mode, use Ctrl-C or type 'q' and press the Enter key.");
+                            info("Press the Enter key to run tests on demand.");
+                        }
+
+                        // the following will be printed only on first startup
+                        if (!printedStartupMessages) {
+                            if (container) {
+                                info("If you need to rebuild the Docker image and restart the container, type 'r' and press the Enter key.");
+                            } else {
+                                info("If you need to restart the server, type 'r' and press the Enter key.");
+                            }
+                            info("To stop the server and quit dev mode, use Ctrl-C or type 'q' and press the Enter key.");
+                            printedStartupMessages = true;
                         }
                     } else {
                         debug("Cannot read user input, setting hotTests to true.");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2275,7 +2275,7 @@ public abstract class DevUtil {
                 debug("Server is restarting. Allowing dev mode to continue.");
                 return;
             }
-            if (!this.devStop.get()) {
+            if (!devStop.get()) {
                 // an external situation caused the server to stop
                 if (container) {
                     throw new PluginScenarioException("The container has stopped. Exiting dev mode.");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1695,12 +1695,12 @@ public abstract class DevUtil {
                         // it's available
                         inputUnavailable.wait(500);
                     }
-                    if (!inputUnavailable.get()) {
-                        // the following will be printed only on first startup
-                        if (!printedStartupMessages) {
-                            info("Liberty dev mode has started!");
-                        }
+                    // the following will be printed only on first startup
+                    if (!printedStartupMessages) {
+                        info("Liberty dev mode has started!");
+                    }
 
+                    if (!inputUnavailable.get()) {
                         // the following will be printed every time after the tests run
                         if (hotTests) {
                             info("Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.");
@@ -1716,13 +1716,13 @@ public abstract class DevUtil {
                                 info("If you need to restart the server, type 'r' and press the Enter key.");
                             }
                             info("To stop the server and quit dev mode, use Ctrl-C or type 'q' and press the Enter key.");
-                            printedStartupMessages = true;
                         }
                     } else {
                         debug("Cannot read user input, setting hotTests to true.");
                         info("Tests will run automatically when changes are detected.");
                         hotTests = true;
                     }
+                    printedStartupMessages = true;
                 } catch (InterruptedException e) {
                     debug("Interrupted while waiting to determine whether input can be read", e);
                 }


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/927

Add a hotkey where you type 'r' and press Enter to restart the server.  If using container mode, this will rebuild the image and restart the container instead.

Update dev mode startup messages to include this.

Update Dockerfile warnings to suggest this hotkey for the COPY commands that are currently not supported for hot deployment.

Adds formatting to dev mode startup messages as follows:
```
[INFO] ************************************************************************
[INFO] *    Liberty dev mode has started!
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************
```
or the below for non-container:
```
[INFO] ************************************************************************
[INFO] *    Liberty dev mode has started!
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************
```