### PR TITLE
Display stdout and stderr when running docker build just like docker run

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1058,19 +1058,11 @@ public abstract class DevUtil {
     }
 
     private String runCmd(String cmd) throws IOException, InterruptedException {
-        return runCmd(true, cmd);
-    }
-
-    private String runCmd(boolean report, String cmd) throws IOException, InterruptedException {
         String result = null;
         Process p = Runtime.getRuntime().exec(cmd);
         p.waitFor(5, TimeUnit.SECONDS);
         if (p.exitValue() != 0) {
-            if (report) {
-                error("Error running command:" + cmd + ", return value=" + p.exitValue());
-            } else {
-                debug("Error running command:" + cmd + ", return value=" + p.exitValue());
-            }
+            error("Error running command:" + cmd + ", return value=" + p.exitValue());
         } else {
             result = readStdOut(p);
         }
@@ -1148,7 +1140,7 @@ public abstract class DevUtil {
         String result = null;
         try {
             debug("execDocker, timeout=" + timeout + ", cmd=" + command);
-            final Process p = Runtime.getRuntime().exec(command);
+            Process p = Runtime.getRuntime().exec(command);
 
             p.waitFor(timeout, TimeUnit.SECONDS);
 

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -952,6 +952,7 @@ public abstract class DevUtil {
             buildCmd = "docker build -f " + tempDockerfile + " -t " + imageName + " " + userDockerfile.getParent();
             info(buildCmd);
             execDockerCmd(buildCmd, dockerBuildTimeout);
+            info("Completed building Docker image.");
         } catch (RuntimeException r) {
             error("Error building Docker image: " + r.getMessage());
             throw new PluginExecutionException("Could not build Docker image using Dockerfile: " + userDockerfile.getAbsolutePath() + ". Address the following docker build error and then start dev mode again: " + r.getMessage(), r);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -951,8 +951,7 @@ public abstract class DevUtil {
             debug("Docker build context: " + userDockerfile.getParent());
             buildCmd = "docker build -f " + tempDockerfile + " -t " + imageName + " " + userDockerfile.getParent();
             info(buildCmd);
-            String buildOutput = execDockerCmd(buildCmd, dockerBuildTimeout);
-            debug("Docker build output: " + buildOutput);
+            execDockerCmd(buildCmd, dockerBuildTimeout);
         } catch (RuntimeException r) {
             error("Error building Docker image: " + r.getMessage());
             throw new PluginExecutionException("Could not build Docker image using Dockerfile: " + userDockerfile.getAbsolutePath() + ". Address the following docker build error and then start dev mode again: " + r.getMessage(), r);
@@ -1098,8 +1097,22 @@ public abstract class DevUtil {
         try {
             debug("execDocker, timeout=" + timeout + ", cmd=" + command);
             long startTime = System.currentTimeMillis();
-            Process p = Runtime.getRuntime().exec(command);
+            final Process p = Runtime.getRuntime().exec(command);
+
+            // Echo docker build output in real time. Other command output handled after process exits.
+            if (command.startsWith("docker build")) {
+                Thread logCopyThread = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        copyStreamToBuildLog(p.getInputStream(), true);
+                    }
+                });
+                logCopyThread.start();
+            }
+
             p.waitFor(timeout, TimeUnit.SECONDS);
+
+            // After waiting for the process, handle the error case and normal termination.
             if (p.exitValue() != 0) {
                 debug("Error running docker command, return value="+p.exitValue());
                 // read messages from standard err
@@ -1108,10 +1121,27 @@ public abstract class DevUtil {
                 String errorMessage = new String(d).trim()+" RC="+p.exitValue();
                 throw new RuntimeException(errorMessage);
             }
+
             if (command.startsWith("docker build")) {
+                // Docker build output already echoed to the console
                 checkDockerIgnore(startTime);
+<<<<<<< HEAD
             }
             result = readStdOut(p);
+=======
+            } else {
+                // Read all the output on stdout and return it to the caller
+                BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+                String line;
+                StringBuffer allLines = new StringBuffer();
+                while ((line = in.readLine())!= null) {
+                    allLines.append(line);
+                }
+                if (allLines.length() > 0) {
+                    result = allLines.toString();
+                }
+            }
+>>>>>>> 7dc8822... Print docker build output on the dev mode console.
         } catch (IllegalThreadStateException  e) {
             // the timeout was too short and the docker command has not yet completed. There is no exit value.
             debug("IllegalThreadStateException, message="+e.getMessage());


### PR DESCRIPTION
I moved some code around so the diffs look a little bigger.
Also, docker build goes into "console mode" when you redirect the output rather than display it on a terminal.
Fixes OpenLiberty/ci.maven#925