### PR TITLE
946 port properties

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1474,11 +1474,7 @@ public abstract class DevUtil {
         }
         String parsedHttpPort = webAppMessage.substring(portIndex, portEndIndex);
         debug("Parsed http port: " + parsedHttpPort);
-        if (container) {
-            httpPort = findLocalPort(parsedHttpPort);
-        } else {
-            httpPort = parsedHttpPort;
-        }
+        httpPort = (container ? findLocalPort(parsedHttpPort) : parsedHttpPort);
     }
 
     protected void parseHttpsPort(List<String> messages) throws PluginExecutionException {
@@ -1492,11 +1488,7 @@ public abstract class DevUtil {
                     String parsedHttpsPort = getPortFromMessageTokens(messageTokens);
                     if (parsedHttpsPort != null) {
                         debug("Parsed https port: " + parsedHttpsPort);
-                        if (container) {
-                            httpsPort = findLocalPort(parsedHttpsPort);
-                        } else {
-                            httpsPort = parsedHttpsPort;
-                        }
+                        httpsPort = (container ? findLocalPort(parsedHttpsPort) : parsedHttpsPort);
                         return;
                     } else {
                         throw new PluginExecutionException(
@@ -1835,6 +1827,15 @@ public abstract class DevUtil {
                                 info(formatAttentionMessage("To restart the server, type 'r' and press Enter."));
                             }
                             info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+                            if (httpPort != null) {
+                                info(formatAttentionMessage("Liberty local http port: " + httpPort));
+                            }
+                            if (httpsPort != null) {
+                                info(formatAttentionMessage("Liberty local https port: " + httpsPort));
+                            }
+                            if (libertyDebug) {
+                                info(formatAttentionMessage("Liberty debug port: " + (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort)));
+                            }
                         }
                     } else {
                         debug("Cannot read user input, setting hotTests to true.");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1520,12 +1520,11 @@ public abstract class DevUtil {
             error("Unable to retrieve locally mapped port.");
             return null;
         }
-        String[] cmdResultSplit = cmdResult.split("RC=");
-        if (cmdResultSplit[cmdResultSplit.length - 1].equals("1")) {
-            error("Unable to retrieve locally mapped port. Docker result: \"" + cmdResultSplit[0] + "\". Ensure the Docker ports are mapped correctly.");
+        if (cmdResult.contains(" RC=")) { // This piece of the string is added in execDockerCmd if there is an error
+            error("Unable to retrieve locally mapped port. Docker result: \"" + cmdResult.split(" RC=")[0] + "\". Ensure the Docker ports are mapped correctly.");
             return null;
         }
-        cmdResultSplit = cmdResult.split(":");
+        String[] cmdResultSplit = cmdResult.split(":");
         String localPort = cmdResultSplit[cmdResultSplit.length - 1];
         debug("Local port: " + localPort);
         return localPort;
@@ -1836,7 +1835,12 @@ public abstract class DevUtil {
                                 }
                             }
                             if (libertyDebug) {
-                                info(formatAttentionMessage("Liberty debug port: " + (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort)));
+                                int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
+                                if (container) {
+                                    info(formatAttentionMessage("Liberty debug port mapped to Docker host port: " + debugPort));
+                                } else {
+                                    info(formatAttentionMessage("Liberty debug port: " + debugPort));
+                                }
                             }
                         }
                     } else {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1217,16 +1217,7 @@ public abstract class DevUtil {
     private String getContainerCommand() {
         StringBuilder command = new StringBuilder("docker run --rm");
         if (!skipDefaultPorts) {
-            if (httpPort != null) {
-                command.append(" -p "+httpPort+":"+httpPort);
-            } else {
-                command.append(" -p 9080:9080");
-            }
-            if (httpsPort != null) {
-                command.append(" -p "+httpsPort+":"+httpsPort);
-            } else {
-                command.append(" -p 9443:9443");
-            }
+            command.append(" -p 9080:9080  -p 9443:9443");
         }
         
         if (libertyDebug) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1217,7 +1217,7 @@ public abstract class DevUtil {
     private String getContainerCommand() {
         StringBuilder command = new StringBuilder("docker run --rm");
         if (!skipDefaultPorts) {
-            command.append(" -p 9080:9080  -p 9443:9443");
+            command.append(" -p 9080:9080 -p 9443:9443");
         }
         
         if (libertyDebug) {
@@ -1520,11 +1520,12 @@ public abstract class DevUtil {
             error("Unable to retrieve locally mapped port.");
             return null;
         }
-        String[] cmdResultSplit = cmdResult.split(":");
-        if (cmdResultSplit[0].equals("Error")) {
-            error("Unable to retrieve locally mapped port. Docker result: \"" + cmdResult + "\". Ensure the Docker ports are mapped correctly.");
+        String[] cmdResultSplit = cmdResult.split("RC=");
+        if (cmdResultSplit[cmdResultSplit.length - 1].equals("1")) {
+            error("Unable to retrieve locally mapped port. Docker result: \"" + cmdResultSplit[0] + "\". Ensure the Docker ports are mapped correctly.");
             return null;
         }
+        cmdResultSplit = cmdResult.split(":");
         String localPort = cmdResultSplit[cmdResultSplit.length - 1];
         debug("Local port: " + localPort);
         return localPort;
@@ -1817,12 +1818,22 @@ public abstract class DevUtil {
                             } else {
                                 info(formatAttentionMessage("To restart the server, type 'r' and press Enter."));
                             }
+
                             info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+
                             if (httpPort != null) {
-                                info(formatAttentionMessage("Liberty local http port: " + httpPort));
+                                if (container) {
+                                    info(formatAttentionMessage("Liberty server HTTP port mapped to Docker host port: " + httpPort));
+                                } else {
+                                    info(formatAttentionMessage("Liberty server HTTP port: " + httpPort));
+                                }
                             }
                             if (httpsPort != null) {
-                                info(formatAttentionMessage("Liberty local https port: " + httpsPort));
+                                if (container) {
+                                    info(formatAttentionMessage("Liberty server HTTPS port mapped to Docker host port: " + httpsPort));
+                                } else {
+                                    info(formatAttentionMessage("Liberty server HTTPS port: " + httpsPort));
+                                }
                             }
                             if (libertyDebug) {
                                 info(formatAttentionMessage("Liberty debug port: " + (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort)));


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/946

I am not sure if we should use "Liberty" port or "Application" port.
I also decided to add the debug port as well.
Here are some example outputs with both the errors and startup messages together:

```
[INFO] ************************************************************************
[INFO] *    Liberty dev mode has started!
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        Liberty local http port: 32773
[INFO] *        Liberty local https port: 32772
[INFO] *        Liberty debug port: 7777
[INFO] ************************************************************************
```

```
[ERROR] Unable to retrieve locally mapped port. Docker result: "Error: No public port '9443/tcp' published for liberty_dev RC=1". Ensure the Docker ports are mapped correctly.
[INFO] ************************************************************************
[INFO] *    Liberty dev mode has started!
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        Liberty local http port: 8000
[INFO] *        Liberty debug port: 7777
[INFO] ************************************************************************
```

```
[ERROR] Unable to retrieve locally mapped port. Docker result: "Error: No public port '9080/tcp' published for liberty_dev RC=1". Ensure the Docker ports are mapped correctly.
[ERROR] Unable to retrieve locally mapped port. Docker result: "Error: No public port '9443/tcp' published for liberty_dev RC=1". Ensure the Docker ports are mapped correctly.
[INFO] ************************************************************************
[INFO] *    Liberty dev mode has started!
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        Liberty debug port: 7777
[INFO] ************************************************************************
```