### PR TITLE
Remove quotes before checking container name

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1275,7 +1275,7 @@ public abstract class DevUtil {
         String[] containerNames = result.split(" ");
         int highestNum = -1;
         for(int i = 0; i < containerNames.length; i++) {
-            String name = containerNames[i];
+            String name = removeSurroundingQuotes(containerNames[i]);
             int num = -1;
             if (name.equals(DEVMODE_CONTAINER_BASE_NAME)) {
                 num = 0;
@@ -1297,6 +1297,13 @@ public abstract class DevUtil {
         }
         
         return DEVMODE_CONTAINER_BASE_NAME + ((highestNum != -1) ? "_" + ++highestNum : "");
+    }
+
+    protected static String removeSurroundingQuotes(String str) {
+        if (str != null && str.length() >= 2 && str.startsWith("\"") && str.endsWith("\"")) {
+            return str.substring(1, str.length()-1);
+        }
+        return str;
     }
 
     // Read all the files from the array list.

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -425,4 +425,18 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertTrue("File should be detected as a generated file", util.isGeneratedConfigFile(sourceFile, configDirectory, targetDir));
     }
 
+    @Test
+    public void testRemoveSurroundingQuotes() {
+        assertEquals("liberty_dev", DevUtil.removeSurroundingQuotes("liberty_dev"));
+
+        // one-sided quote should not be removed
+        assertEquals("\"", DevUtil.removeSurroundingQuotes("\""));
+        assertEquals("\"liberty_dev", DevUtil.removeSurroundingQuotes("\"liberty_dev"));
+        assertEquals("liberty_dev\"", DevUtil.removeSurroundingQuotes("liberty_dev\""));
+
+        // surrounding quotes should be removed
+        assertEquals("liberty_dev", DevUtil.removeSurroundingQuotes("\"liberty_dev\""));
+        assertEquals("", DevUtil.removeSurroundingQuotes("\"\""));
+    }
+
 }


### PR DESCRIPTION
On Mac, the string returned from `docker ps` has quotes around each of container names.  Check if the container name has surrounding quotes, and if it does, remove them before processing.

Fixes https://github.com/OpenLiberty/ci.maven/issues/951