### PR TITLE
Print dev mode startup messages on server/container restart

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1814,7 +1814,7 @@ public abstract class DevUtil {
     /**
      * Print the dev mode startup and/or run tests messages.
      * 
-     * @param inputUnavailable If true, that the console is non-interactive so hotkeys should not be printed.
+     * @param inputUnavailable If true, indicates that the console is non-interactive so hotkey messages should not be printed.
      * @param startup If true, include attention barriers (asterisks lines) and overall dev mode startup messages such as list of hotkeys and ports.
      */
     private void printDevModeMessages(boolean inputUnavailable, boolean startup) {


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/952

It will now print something like:
```
[INFO] The server has been restarted.
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        Liberty server HTTP port mapped to Docker host port: 32817
[INFO] *        Liberty server HTTPS port mapped to Docker host port: 32816
[INFO] *        Liberty debug port mapped to Docker host port: 7777
[INFO] ************************************************************************
```

Message on first start has also been changed to `Liberty is running in dev mode.`

This affects both non-container and container mode.