### PR TITLE
Handle Dockerfile ADD commands

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -971,7 +971,6 @@ public abstract class DevUtil {
         for (String line : dockerfileLines) {
             debug(line);
         }
-//        debug(dockerfileLines.stream().collect(java.util.stream.Collectors.joining("\n")));
 
         File tempDockerfile = null;
         try {
@@ -2300,6 +2299,14 @@ public abstract class DevUtil {
         registerSingleFile(registerFile, executor, false);
     }
 
+    /**
+     * Register a single file with the WatchService using a file filter.
+     * 
+     * @param registerFile             the file of interest
+     * @param executor                 the test thread executor
+     * @param removeOnContainerRebuild whether the files should be unwatched if the container is rebuilt
+     * @throws IOException unable to read the canonical path name
+     */
     private void registerSingleFile(final File registerFile, final ThreadPoolExecutor executor, boolean removeOnContainerRebuild) throws IOException {
         if (trackingMode == FileTrackMode.POLLING || trackingMode == FileTrackMode.NOT_SET) {
             String parentPath = registerFile.getParentFile().getCanonicalPath();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -846,7 +846,7 @@ public abstract class DevUtil {
                 if (cmdSegments[0].equalsIgnoreCase("COPY") || cmdSegments[0].equalsIgnoreCase("ADD")) {
                     if (cmdSegments.length < 3) {
                         throw new PluginExecutionException("Incorrect syntax on this line in the Dockerfile: '" + line + 
-                        "'. There must be at least two arguments for the COPY command, a source path and a destination path.");
+                        "'. There must be at least two arguments for the COPY or ADD command, a source path and a destination path.");
                     }
                     if (cmdSegments[cmdSegments.length - 2].toLowerCase().endsWith(".war")) {
                         warFileLines.add(line);
@@ -891,18 +891,18 @@ public abstract class DevUtil {
                 if (cmdSegments[0].equalsIgnoreCase("COPY") || cmdSegments[0].equalsIgnoreCase("ADD")) {
                     if (cmdSegments.length < 3) { // preliminary check but some of these segments could be options
                         throw new PluginExecutionException("Incorrect syntax on this line in the Dockerfile: '" + line + 
-                        "'. There must be at least two arguments for the COPY command, a source path and a destination path.");
+                        "'. There must be at least two arguments for the COPY or ADD command, a source path and a destination path.");
                     }
                     if (line.contains("$")) {
-                        warn("The Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support environment variables in COPY commands. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
+                        warn("The Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support environment variables in COPY or ADD commands. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
                         continue;
                     }
                     List<String> srcOrDestArguments = new ArrayList<String>();
                     boolean skipLine = false;
-                    for (int i = 1; i < cmdSegments.length; i++) { // start after the COPY word
+                    for (int i = 1; i < cmdSegments.length; i++) { // start after the word COPY (or ADD)
                         String segment = cmdSegments[i];
                         if (segment.startsWith("--from")) {
-                            // multi-stage build, give a warning
+                            // multi-stage build, COPY only (not ADD), give a warning
                             warn("The Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support hot deployment with multi-stage COPY commands.");
                             skipLine = true; // don't mount the dirs in this COPY command
                             break;
@@ -926,7 +926,7 @@ public abstract class DevUtil {
                         String sourcePath = buildContext + "/" + src;
                         File sourceFile = new File(sourcePath);
                         if (src.contains("*") || src.contains("?")) {
-                            warn("The COPY source " + src + " in the Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support wildcards in the COPY command. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
+                            warn("The COPY or ADD source " + src + " in the Dockerfile line '" + line + "' will not be able to be hot deployed to the dev mode container. Dev mode does not currently support wildcards in the COPY or ADD commands. If you make changes to files specified by this line, type 'r' and press Enter to rebuild the Docker image and restart the container.");
                         } else if (sourceFile.isDirectory() || cmdSegments[0].equalsIgnoreCase("ADD")) {
                             synchronized(dockerfileDirectoriesToWatch) {
                                 try {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/962
Also fixes ConcurrentModificationException when registering multiple dockerfileDirectoriesToWatch in the watchFiles loop.
Do we need to build a list of directories registered in case there is an exception? Then remove the list instead of dockerfileDirectoriesToWatch.clear()? It looks like if there *is* an exception then dev mode exits. 
