### PR TITLE
986 internal ports

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1887,6 +1887,7 @@ public abstract class DevUtil {
             hotTests = true;
         }
         if (startup) {
+            info(formatAttentionMessage(""));
             info(formatAttentionTitle("Liberty server port information:"));
             if (httpPort != null) {
                 if (container) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -295,6 +295,8 @@ public abstract class DevUtil {
     private String hostName;
     private String httpPort;
     private String httpsPort;
+    private String containerHttpPort;
+    private String containerHttpsPort;
     private final long compileWaitMillis;
     private AtomicBoolean inputUnavailable;
     private int alternativeDebugPort = -1;
@@ -1493,7 +1495,13 @@ public abstract class DevUtil {
         }
         String parsedHttpPort = webAppMessage.substring(portIndex, portEndIndex);
         debug("Parsed http port: " + parsedHttpPort);
-        httpPort = (container ? findLocalPort(parsedHttpPort) : parsedHttpPort);
+        if (container) {
+            httpPort = findLocalPort(parsedHttpPort);
+            containerHttpPort = parsedHttpPort;
+        }
+        else {
+            httpPort = parsedHttpPort;
+        }
     }
 
     protected void parseHttpsPort(List<String> messages) throws PluginExecutionException {
@@ -1507,7 +1515,13 @@ public abstract class DevUtil {
                     String parsedHttpsPort = getPortFromMessageTokens(messageTokens);
                     if (parsedHttpsPort != null) {
                         debug("Parsed https port: " + parsedHttpsPort);
-                        httpsPort = (container ? findLocalPort(parsedHttpsPort) : parsedHttpsPort);
+                        if (container) {
+                            httpsPort = findLocalPort(parsedHttpsPort);
+                            containerHttpsPort = parsedHttpsPort;
+                        }
+                        else {
+                            httpsPort = parsedHttpsPort;
+                        }
                         return;
                     } else {
                         throw new PluginExecutionException(
@@ -1873,6 +1887,7 @@ public abstract class DevUtil {
             hotTests = true;
         }
         if (startup) {
+            // TODO: Update start up messages to include internal container ports
             if (httpPort != null) {
                 if (container) {
                     info(formatAttentionMessage("Liberty server HTTP port mapped to Docker host port: " + httpPort));

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1887,17 +1887,19 @@ public abstract class DevUtil {
             hotTests = true;
         }
         if (startup) {
-            // TODO: Update start up messages to include internal container ports
+            info(formatAttentionTitle("Liberty server port information:"));
             if (httpPort != null) {
                 if (container) {
-                    info(formatAttentionMessage("Liberty server HTTP port mapped to Docker host port: " + httpPort));
+                    info(formatAttentionMessage("Internal container HTTP port: " + containerHttpPort));
+                    info(formatAttentionMessage("Mapped Docker host HTTP port: " + httpPort));
                 } else {
                     info(formatAttentionMessage("Liberty server HTTP port: " + httpPort));
                 }
             }
             if (httpsPort != null) {
                 if (container) {
-                    info(formatAttentionMessage("Liberty server HTTPS port mapped to Docker host port: " + httpsPort));
+                    info(formatAttentionMessage("Internal container HTTPS port: " + containerHttpsPort));
+                    info(formatAttentionMessage("Mapped Docker host HTTPS port: " + httpsPort));
                 } else {
                     info(formatAttentionMessage("Liberty server HTTPS port: " + httpsPort));
                 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/986

Example output:

**dev**
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *    Liberty server port information:
[INFO] *        Liberty server HTTP port: 9080
[INFO] *        Liberty server HTTPS port: 9443
[INFO] *        Liberty debug port: 7777
[INFO] ************************************************************************
```

**devc**
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *    Liberty server port information:
[INFO] *        Internal container HTTP port: 9080
[INFO] *        Mapped Docker host HTTP port: 32777
[INFO] *        Internal container HTTPS port: 9443
[INFO] *        Mapped Docker host HTTPS port: 32776
[INFO] *        Liberty debug port mapped to Docker host port: 7777
[INFO] ************************************************************************
```