### PR TITLE
Support compiler options for dev mode recompile

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -328,12 +328,14 @@ public abstract class DevUtil {
     private Set<Path> dockerfileDirectoriesTracked = new HashSet<Path>();
     private Set<WatchKey> dockerfileDirectoriesWatchKeys = new HashSet<WatchKey>();
     private Set<FileAlterationObserver> dockerfileDirectoriesFileObservers = new HashSet<FileAlterationObserver>();
+    private final JavaCompilerOptions compilerOptions;
 
     public DevUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory, File projectDirectory,
             List<File> resourceDirs, boolean hotTests, boolean skipTests, boolean skipUTs, boolean skipITs,
             String applicationId, long serverStartTimeout, int appStartupTimeout, int appUpdateTimeout,
             long compileWaitMillis, boolean libertyDebug, boolean useBuildRecompile, boolean gradle, boolean pollingTest,
-            boolean container, File dockerfile, String dockerRunOpts, int dockerBuildTimeout, boolean skipDefaultPorts) {
+            boolean container, File dockerfile, String dockerRunOpts, int dockerBuildTimeout, boolean skipDefaultPorts, 
+            JavaCompilerOptions compilerOptions) {
         this.serverDirectory = serverDirectory;
         this.sourceDirectory = sourceDirectory;
         this.testSourceDirectory = testSourceDirectory;
@@ -377,6 +379,7 @@ public abstract class DevUtil {
             this.dockerBuildTimeout = dockerBuildTimeout;
         }
         this.skipDefaultPorts = skipDefaultPorts;
+        this.compilerOptions = compilerOptions;
     }
 
     /**
@@ -3221,7 +3224,11 @@ public abstract class DevUtil {
                     }
                 }
 
-                List<String> optionList = new ArrayList<>(Arrays.asList(DEFAULT_COMPILER_OPTIONS));
+                Set<String> combinedCompilerOptions = new HashSet<>(Arrays.asList(DEFAULT_COMPILER_OPTIONS));
+                if (compilerOptions != null) {
+                    combinedCompilerOptions.addAll(compilerOptions.getOptions());
+                }
+
                 List<File> outputDirs = new ArrayList<File>();
 
                 if (tests) {
@@ -3249,7 +3256,7 @@ public abstract class DevUtil {
                     }
                 }
 
-                JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, null, optionList, null,
+                JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, null, combinedCompilerOptions, null,
                         compilationUnits);
 
                 compileResult = task.call();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3224,10 +3224,11 @@ public abstract class DevUtil {
                     }
                 }
 
-                Set<String> combinedCompilerOptions = new HashSet<>(Arrays.asList(DEFAULT_COMPILER_OPTIONS));
+                List<String> combinedCompilerOptions = new ArrayList<>(Arrays.asList(DEFAULT_COMPILER_OPTIONS));
                 if (compilerOptions != null) {
                     combinedCompilerOptions.addAll(compilerOptions.getOptions());
                 }
+                debug("Compiler options: " + combinedCompilerOptions);
 
                 List<File> outputDirs = new ArrayList<File>();
 
@@ -3291,7 +3292,8 @@ public abstract class DevUtil {
                 return false;
             }
         } catch (Exception e) {
-            debug("Error compiling java files", e);
+            error("Error compiling Java files: " + e.getMessage());
+            debug(e);
             return false;
         }
     }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -1,0 +1,67 @@
+/**
+ * (C) Copyright IBM Corporation 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openliberty.tools.common.plugins.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class JavaCompilerOptions {
+    
+    /**
+     * Source Java version
+     */
+    private String source;
+
+    /**
+     * Target Java version
+     */
+    private String target;
+
+    /**
+     * Set of options that can be passed to the compiler.
+     * @return
+     */
+    public Set<String> getOptions() {
+        Set<String> options = new HashSet<String>();
+        addStringOption(options, "source", source);
+        addStringOption(options, "target", target);
+        return options;
+    }
+
+    private static void addStringOption(Set<String> options, String optionName, String optionValue) {
+        if (optionValue != null && !optionValue.trim().isEmpty()) {
+            options.add("-" + optionName + " " + optionValue.trim());
+        }
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+}

--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -16,8 +16,8 @@
 
 package io.openliberty.tools.common.plugins.util;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JavaCompilerOptions {
     
@@ -32,19 +32,23 @@ public class JavaCompilerOptions {
     private String target;
 
     /**
-     * Set of options that can be passed to the compiler.
-     * @return
+     * Get list of options that can be passed to the compiler.
+     * Options with values are represented as multiple strings in the list
+     *  e.g. "-source" and "1.8"
+     * 
+     * @return List of options
      */
-    public Set<String> getOptions() {
-        Set<String> options = new HashSet<String>();
+    public List<String> getOptions() {
+        List<String> options = new ArrayList<String>();
         addStringOption(options, "source", source);
         addStringOption(options, "target", target);
         return options;
     }
 
-    private static void addStringOption(Set<String> options, String optionName, String optionValue) {
+    private static void addStringOption(List<String> options, String optionName, String optionValue) {
         if (optionValue != null && !optionValue.trim().isEmpty()) {
-            options.add("-" + optionName + " " + optionValue.trim());
+            options.add("-" + optionName);
+            options.add(optionValue.trim());
         }
     }
 

--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -32,6 +32,16 @@ public class JavaCompilerOptions {
     private String target;
 
     /**
+     * Java release version
+     */
+    private String release;
+
+    /**
+     * Whether to show warnings. Default is false.
+     */
+    private boolean showWarnings = false;
+
+    /**
      * Get list of options that can be passed to the compiler.
      * Options with values are represented as multiple strings in the list
      *  e.g. "-source" and "1.8"
@@ -40,14 +50,18 @@ public class JavaCompilerOptions {
      */
     public List<String> getOptions() {
         List<String> options = new ArrayList<String>();
-        addStringOption(options, "source", source);
-        addStringOption(options, "target", target);
+        if (!showWarnings) {
+            options.add("-nowarn");
+        }
+        addStringOption(options, "-source", source);
+        addStringOption(options, "-target", target);
+        addStringOption(options, "--release", release);
         return options;
     }
 
-    private static void addStringOption(List<String> options, String optionName, String optionValue) {
+    private static void addStringOption(List<String> options, String optionKey, String optionValue) {
         if (optionValue != null && !optionValue.trim().isEmpty()) {
-            options.add("-" + optionName);
+            options.add(optionKey);
             options.add(optionValue.trim());
         }
     }
@@ -66,6 +80,22 @@ public class JavaCompilerOptions {
 
     public void setTarget(String target) {
         this.target = target;
+    }
+
+    public boolean isShowWarnings() {
+        return showWarnings;
+    }
+
+    public void setShowWarnings(boolean showWarnings) {
+        this.showWarnings = showWarnings;
+    }
+
+    public String getRelease() {
+        return release;
+    }
+
+    public void setRelease(String release) {
+        this.release = release;
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -36,7 +36,7 @@ public class BaseDevUtilTest {
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, resourceDirs, hotTests, skipTests, 
-                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, 0, false);
+                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, 0, false, null);
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -18,7 +18,7 @@ package io.openliberty.tools.common.plugins.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -30,17 +30,19 @@ public class JavaCompilerOptionsTest {
         jco.setSource("9");
         jco.setTarget("1.8");
 
-        Set<String> result = jco.getOptions();
-        assertEquals(2, result.size());
-        assertTrue(result.contains("-source 9"));
-        assertTrue(result.contains("-target 1.8"));
+        List<String> result = jco.getOptions();
+        assertEquals(4, result.size());
+        assertTrue(result.get(0).equals("-source"));
+        assertTrue(result.get(1).equals("9"));
+        assertTrue(result.get(2).equals("-target"));
+        assertTrue(result.get(3).equals("1.8"));
     }
     
     @Test
     public void testNoOptions() throws Exception {
         JavaCompilerOptions jco = new JavaCompilerOptions();
 
-        Set<String> result = jco.getOptions();
+        List<String> result = jco.getOptions();
         assertEquals(0, result.size());
     }
 
@@ -49,9 +51,10 @@ public class JavaCompilerOptionsTest {
         JavaCompilerOptions jco = new JavaCompilerOptions();
         jco.setSource("10");
 
-        Set<String> result = jco.getOptions();
-        assertEquals(1, result.size());
-        assertTrue(result.contains("-source 10"));
+        List<String> result = jco.getOptions();
+        assertEquals(2, result.size());
+        assertTrue(result.get(0).equals("-source"));
+        assertTrue(result.get(1).equals("10"));
     }
 
     @Test
@@ -59,9 +62,10 @@ public class JavaCompilerOptionsTest {
         JavaCompilerOptions jco = new JavaCompilerOptions();
         jco.setTarget("10");
 
-        Set<String> result = jco.getOptions();
-        assertEquals(1, result.size());
-        assertTrue(result.contains("-target 10"));
+        List<String> result = jco.getOptions();
+        assertEquals(2, result.size());
+        assertTrue(result.get(0).equals("-target"));
+        assertTrue(result.get(1).equals("10"));
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -1,0 +1,67 @@
+/**
+ * (C) Copyright IBM Corporation 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.common.plugins.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+public class JavaCompilerOptionsTest {
+
+    @Test
+    public void testAllOptions() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setSource("9");
+        jco.setTarget("1.8");
+
+        Set<String> result = jco.getOptions();
+        assertEquals(2, result.size());
+        assertTrue(result.contains("-source 9"));
+        assertTrue(result.contains("-target 1.8"));
+    }
+    
+    @Test
+    public void testNoOptions() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+
+        Set<String> result = jco.getOptions();
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testSource() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setSource("10");
+
+        Set<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.contains("-source 10"));
+    }
+
+    @Test
+    public void testTarget() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setTarget("10");
+
+        Set<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.contains("-target 10"));
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -27,23 +27,29 @@ public class JavaCompilerOptionsTest {
     @Test
     public void testAllOptions() throws Exception {
         JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setShowWarnings(true);
         jco.setSource("9");
         jco.setTarget("1.8");
-
+        jco.setRelease("10");
+        
         List<String> result = jco.getOptions();
-        assertEquals(4, result.size());
-        assertTrue(result.get(0).equals("-source"));
-        assertTrue(result.get(1).equals("9"));
-        assertTrue(result.get(2).equals("-target"));
-        assertTrue(result.get(3).equals("1.8"));
+        int i = 0;
+        assertTrue(result.get(i++).equals("-source"));
+        assertTrue(result.get(i++).equals("9"));
+        assertTrue(result.get(i++).equals("-target"));
+        assertTrue(result.get(i++).equals("1.8"));
+        assertTrue(result.get(i++).equals("--release"));
+        assertTrue(result.get(i++).equals("10"));
+        assertEquals(i, result.size());
     }
     
     @Test
-    public void testNoOptions() throws Exception {
+    public void testDefaultOptions() throws Exception {
         JavaCompilerOptions jco = new JavaCompilerOptions();
 
         List<String> result = jco.getOptions();
-        assertEquals(0, result.size());
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
     }
 
     @Test
@@ -52,9 +58,10 @@ public class JavaCompilerOptionsTest {
         jco.setSource("10");
 
         List<String> result = jco.getOptions();
-        assertEquals(2, result.size());
-        assertTrue(result.get(0).equals("-source"));
-        assertTrue(result.get(1).equals("10"));
+        assertEquals(3, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+        assertTrue(result.get(1).equals("-source"));
+        assertTrue(result.get(2).equals("10"));
     }
 
     @Test
@@ -63,9 +70,22 @@ public class JavaCompilerOptionsTest {
         jco.setTarget("10");
 
         List<String> result = jco.getOptions();
-        assertEquals(2, result.size());
-        assertTrue(result.get(0).equals("-target"));
-        assertTrue(result.get(1).equals("10"));
+        assertEquals(3, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+        assertTrue(result.get(1).equals("-target"));
+        assertTrue(result.get(2).equals("10"));
+    }
+
+    @Test
+    public void testRelease() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setRelease("10");
+
+        List<String> result = jco.getOptions();
+        assertEquals(3, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+        assertTrue(result.get(1).equals("--release"));
+        assertTrue(result.get(2).equals("10"));
     }
 
 }


### PR DESCRIPTION
Add ability to pass "-source", "-target", "--release", and "-nowarn" options to the compiler.

Part of https://github.com/OpenLiberty/ci.maven/issues/968