### PR TITLE
Update to use ci.ant snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.6-SNAPSHOT</version>
         </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Updating to ci.ant snapshot for PR OpenLiberty/ci.ant#130.