### PR TITLE
Reformat startup message

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1933,33 +1933,48 @@ public abstract class DevUtil {
             hotTests = true;
         }
         if (startup) {
-            info(formatAttentionMessage(""));
-            info(formatAttentionTitle("Liberty server port information:"));
-            if (httpPort != null) {
-                if (container) {
-                    info(formatAttentionMessage("Internal container HTTP port: " + containerHttpPort));
-                    info(formatAttentionMessage("Mapped Docker host HTTP port: " + httpPort));
-                } else {
-                    info(formatAttentionMessage("Liberty server HTTP port: " + httpPort));
+            if (container) {
+                if (containerHttpPort != null || containerHttpsPort != null || libertyDebug) {
+                    info(formatAttentionMessage(""));
+                    info(formatAttentionTitle("Liberty container port information:"));
+                }
+                if (containerHttpPort != null) {
+                    if (httpPort != null) {
+                        info(formatAttentionMessage("Internal container HTTP port [ " + containerHttpPort + " ] is mapped to Docker host port [ " + httpPort + " ]"));
+                    }
+                    else {
+                        info(formatAttentionMessage("Internal container HTTP port: [ " + containerHttpPort + " ]"));
+                    }
+                }
+                if (containerHttpsPort != null) {
+                    if (httpsPort != null) {
+                        info(formatAttentionMessage("Internal container HTTPS port [ " + containerHttpsPort + " ] is mapped to Docker host port [ " + httpsPort + " ]"));
+                    }
+                    else {
+                        info(formatAttentionMessage("Internal container HTTPS port: [ " + containerHttpsPort + " ]"));
+                    }
+                }
+                if (libertyDebug) {
+                    int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
+                    info(formatAttentionMessage("Liberty debug port mapped to Docker host port: [ " + debugPort + " ]"));
                 }
             }
-            if (httpsPort != null) {
-                if (container) {
-                    info(formatAttentionMessage("Internal container HTTPS port: " + containerHttpsPort));
-                    info(formatAttentionMessage("Mapped Docker host HTTPS port: " + httpsPort));
-                } else {
-                    info(formatAttentionMessage("Liberty server HTTPS port: " + httpsPort));
+            else {
+                if (httpPort != null || httpsPort != null || libertyDebug) {
+                    info(formatAttentionMessage(""));
+                    info(formatAttentionTitle("Liberty server port information:"));
+                }
+                if (httpPort != null) {
+                    info(formatAttentionMessage("Liberty server HTTP port: [ " + httpPort + " ]"));
+                }
+                if (httpsPort != null) {
+                    info(formatAttentionMessage("Liberty server HTTPS port: [ " + httpsPort + " ]"));
+                }
+                if (libertyDebug) {
+                    int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
+                    info(formatAttentionMessage("Liberty debug port: [ " + debugPort + " ]"));
                 }
             }
-            if (libertyDebug) {
-                int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
-                if (container) {
-                    info(formatAttentionMessage("Liberty debug port mapped to Docker host port: " + debugPort));
-                } else {
-                    info(formatAttentionMessage("Liberty debug port: " + debugPort));
-                }
-            }
-
             // print barrier footer
             info(formatAttentionBarrier());
         }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1000

Example output:

**dev**

```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty server port information:
[INFO] *        Liberty server HTTP port: [ 9080 ]
[INFO] *        Liberty server HTTPS port: [ 9443 ]
[INFO] *        Liberty debug port: [ 7777 ]
[INFO] ************************************************************************
```
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty server port information:
[INFO] *        Liberty server HTTP port: [ 9080 ]
[INFO] ************************************************************************
```

**devc**

```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32775 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32774 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] ************************************************************************
```
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 8000 ]
[INFO] *        Internal container HTTPS port: [ 9443 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] ************************************************************************
```
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] ************************************************************************
```
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************
```