### PR TITLE
Detect when the server http/s ports are used and try the next port in sequence

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1264,7 +1264,7 @@ public abstract class DevUtil {
                 httpPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTP_PORT, false);
                 httpsPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTPS_PORT, false);
             } catch (IOException x) {
-                error("An error occurred while trying to find a free network port, using default port numbers.", x);
+                error("An error occurred while trying to find an available network port. Using default port numbers.", x);
                 httpPortToUse = LIBERTY_DEFAULT_HTTP_PORT;
                 httpsPortToUse = LIBERTY_DEFAULT_HTTPS_PORT;
             }
@@ -1973,7 +1973,7 @@ public abstract class DevUtil {
                     info(formatAttentionMessage(""));
                     info(formatAttentionTitle("Liberty container port information:"));
                 }
-                if (nonDefaultHttpPortUsed || nonDefaultHttpsPortUsed || nonDefaultDebugPortUsed) {
+                if (nonDefaultHttpPortUsed || nonDefaultHttpsPortUsed || (libertyDebug && nonDefaultDebugPortUsed)) {
                     warn(formatAttentionMessage("The Liberty container is using non-default host ports."));
                 }
                 if (containerHttpPort != null) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1264,7 +1264,7 @@ public abstract class DevUtil {
                 httpPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTP_PORT, false);
                 httpsPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTPS_PORT, false);
             } catch (IOException x) {
-                debug("IOException trying to findAvailablePort(), using default ports.");
+                error("An error occurred while trying to find a free network port, using default port numbers.", x);
                 httpPortToUse = LIBERTY_DEFAULT_HTTP_PORT;
                 httpsPortToUse = LIBERTY_DEFAULT_HTTPS_PORT;
             }
@@ -1968,8 +1968,7 @@ public abstract class DevUtil {
             if (container) {
                 boolean nonDefaultHttpPortUsed = !skipDefaultPorts && !String.valueOf(LIBERTY_DEFAULT_HTTP_PORT).equals(httpPort);
                 boolean nonDefaultHttpsPortUsed = !skipDefaultPorts && !String.valueOf(LIBERTY_DEFAULT_HTTPS_PORT).equals(httpsPort);
-                int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
-                boolean nonDefaultDebugPortUsed = !skipDefaultPorts && LIBERTY_DEFAULT_DEBUG_PORT != debugPort;
+                boolean nonDefaultDebugPortUsed = alternativeDebugPort != -1; // this is set when a random ephemeral port is selected
                 if (containerHttpPort != null || containerHttpsPort != null || libertyDebug) {
                     info(formatAttentionMessage(""));
                     info(formatAttentionTitle("Liberty container port information:"));
@@ -2000,6 +1999,7 @@ public abstract class DevUtil {
                     }
                 }
                 if (libertyDebug) {
+                    int debugPort = (alternativeDebugPort == -1 ? libertyDebugPort : alternativeDebugPort);
                     if (!nonDefaultDebugPortUsed) {
                         info(formatAttentionMessage("Liberty debug port mapped to Docker host port: [ " + debugPort + " ]"));
                     } else {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1264,6 +1264,7 @@ public abstract class DevUtil {
                 httpPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTP_PORT, false);
                 httpsPortToUse = findAvailablePort(LIBERTY_DEFAULT_HTTPS_PORT, false);
             } catch (IOException x) {
+                debug("IOException trying to findAvailablePort(), using default ports.");
                 httpPortToUse = LIBERTY_DEFAULT_HTTP_PORT;
                 httpsPortToUse = LIBERTY_DEFAULT_HTTPS_PORT;
             }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -127,7 +127,7 @@ public class DevUtilTest extends BaseDevUtilTest {
         int preferredPort = getRandomPort();
 
         // verify that findAvailablePort gets the preferred port
-        int availablePort = util.findAvailablePort(preferredPort);
+        int availablePort = util.findAvailablePort(preferredPort, true);
         assertEquals(preferredPort, availablePort);
 
         // bind to it
@@ -139,14 +139,18 @@ public class DevUtilTest extends BaseDevUtilTest {
             serverSocket.bind(new InetSocketAddress(InetAddress.getByName(null), availablePort), 1);
 
             // previous port is bound, so calling findAvailablePort again should get another port
-            int availablePort2 = util.findAvailablePort(preferredPort);
+            int availablePort2 = util.findAvailablePort(preferredPort, true);
             assertNotEquals(availablePort, availablePort2);
+
+            // previous port is bound, so calling findAvailablePort again should get the next port in sequence
+            int availablePort5 = util.findAvailablePort(preferredPort, false);
+            assertEquals(preferredPort + 1, availablePort5);
 
             // unbind the port
             serverSocket.close();
 
             // calling findAvailablePort again should return the previous port which was cached, even though the preferred port is available
-            int availablePort3 = util.findAvailablePort(preferredPort);
+            int availablePort3 = util.findAvailablePort(preferredPort, true);
             assertEquals(availablePort2, availablePort3);
 
             // bind to the previous port
@@ -155,7 +159,7 @@ public class DevUtilTest extends BaseDevUtilTest {
             serverSocket2.bind(new InetSocketAddress(InetAddress.getByName(null), availablePort2), 1);
 
             // previous port is now bound, so calling findAvailablePort again should get another port
-            int availablePort4 = util.findAvailablePort(preferredPort);
+            int availablePort4 = util.findAvailablePort(preferredPort, true);
             assertNotEquals(availablePort2, availablePort4);
         } finally {
             if (serverSocket != null) {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/947
I duplicated the message and added ‘<‘ to the second copy because of the semantics indicated by the method formatAttentionMessage() which suggests padding could be added to the beginning or the end. Hopefully in the future these messages will be translated and the separate messages should be easier to translate.