### PR TITLE
987 network info

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1408,13 +1408,13 @@ public abstract class DevUtil {
         String result = execDockerCmd(dockerIPAddressCmd, 10, false);
         if (result == null || result.contains(" RC=")) { // RC is added in execDockerCmd if there is an error
             warn("Unable to retrieve container IP address for network '" + network + "'.");
-            result = "<no value>"; // this is what Docker displays when an IP address it not found for a network
+            return "<no value>"; // this is what Docker displays when an IP address it not found for a network
         }
-        return result;
+        return removeSurroundingQuotes(result.trim());
     }
 
     protected static String removeSurroundingQuotes(String str) {
-        if (str != null && str.length() >= 2 && str.startsWith("\"") && str.endsWith("\"")) {
+        if (str != null && str.length() >= 2 && ((str.startsWith("\"") && str.endsWith("\"")) || (str.startsWith("\'") && str.endsWith("\'")))) {
             return str.substring(1, str.length()-1);
         }
         return str;

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1393,11 +1393,11 @@ public abstract class DevUtil {
         }
         else {
             // Example cmdResult value: map[bridge:0xc000622000 myNet:0xc0006220c0 otherNet:0xc000622180]
-            String resultSub = cmdResult.substring(cmdResult.indexOf("[") + 1, cmdResult.indexOf("]") -1);
-            String[] networkHash = resultSub.split(" ");
-            String[] networks = new String[networkHash.length];
-            for (int i=0; i < networkHash.length; i++) {
-                networks[i] = networkHash[i].split(":")[0];
+            String networkMap = cmdResult.substring(cmdResult.indexOf("[") + 1, cmdResult.indexOf("]") -1);
+            String[] networkHex = networkMap.split(" ");
+            String[] networks = new String[networkHex.length];
+            for (int i=0; i < networkHex.length; i++) {
+                networks[i] = networkHex[i].split(":")[0];
             }
             return networks;
         }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -434,13 +435,46 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertEquals("liberty_dev", DevUtil.removeSurroundingQuotes("liberty_dev"));
 
         // one-sided quote should not be removed
+        // double quotes
         assertEquals("\"", DevUtil.removeSurroundingQuotes("\""));
         assertEquals("\"liberty_dev", DevUtil.removeSurroundingQuotes("\"liberty_dev"));
         assertEquals("liberty_dev\"", DevUtil.removeSurroundingQuotes("liberty_dev\""));
+        // single quotes
+        assertEquals("\'", DevUtil.removeSurroundingQuotes("\'"));
+        assertEquals("\'liberty_dev", DevUtil.removeSurroundingQuotes("\'liberty_dev"));
+        assertEquals("liberty_dev\'", DevUtil.removeSurroundingQuotes("liberty_dev\'"));
 
         // surrounding quotes should be removed
+        // double quotes
         assertEquals("liberty_dev", DevUtil.removeSurroundingQuotes("\"liberty_dev\""));
         assertEquals("", DevUtil.removeSurroundingQuotes("\"\""));
+        // single quotes
+        assertEquals("liberty_dev", DevUtil.removeSurroundingQuotes("\'liberty_dev\'"));
+        assertEquals("", DevUtil.removeSurroundingQuotes("\'\'"));
+    }
+
+    @Test
+    public void testParseNetworks() {
+        String[] networkArray = new String[]{"bridge"};
+        assertArrayEquals(networkArray, DevUtil.parseNetworks("map[bridge:0xc000622000]"));
+
+        networkArray = new String[]{"bridge", "myNet"};
+        assertArrayEquals(networkArray, DevUtil.parseNetworks("map[bridge:0xc000622000 myNet:0xc0006220c0]"));
+
+        networkArray = new String[]{"bridge", "myNet", "otherNet"};
+        assertArrayEquals(networkArray, DevUtil.parseNetworks("map[bridge:0xc000622000 myNet:0xc0006220c0 otherNet:0xc000622180]"));
+
+        networkArray = new String[]{"bridge", "myNet"};
+        assertArrayEquals(networkArray, DevUtil.parseNetworks("map[bridge myNet]"));
+
+        networkArray = new String[]{"bridge", ""};
+        assertArrayEquals(networkArray, DevUtil.parseNetworks("map[bridge: :myNet:]"));
+
+        assertArrayEquals(null, DevUtil.parseNetworks("mapbridge:0xc000622000 myNet:0xc0006220c0 otherNet:0xc000622180]"));
+        assertArrayEquals(null, DevUtil.parseNetworks("map[bridge:0xc000622000 myNet:0xc0006220c0 otherNet:0xc000622180"));
+        assertArrayEquals(null, DevUtil.parseNetworks("[bridge:0xc000622000 myNet:0xc0006220c0 otherNet:0xc000622180]"));
+        assertArrayEquals(null, DevUtil.parseNetworks("string"));
+        assertArrayEquals(null, DevUtil.parseNetworks(""));
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/987

Here is some example output below. Specifically, I'm interested to know if the warning and/or the debug statements should be allowed to break up the startup message box. 

**Example Output**

One network:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32835 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32834 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[INFO] *        IP address [ 172.17.0.3 ] on Docker network [ bridge ]
[INFO] ************************************************************************
```

Multiple networks:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32807 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32806 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[INFO] *        IP address [ 172.17.0.3 ] on Docker network [ bridge ]
[INFO] *        IP address [ 172.18.0.3 ] on Docker network [ mynet ]
[INFO] *        IP address [ 172.19.0.3 ] on Docker network [ thirdNet ]
[INFO] ************************************************************************
```

No IP address for the network:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32813 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32812 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[INFO] *        IP address [ <no value> ] on Docker network [ bridge ]
[INFO] ************************************************************************
```

Unable to retrieve IP address warning:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32815 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32814 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[WARNING] Unable to retrieve container IP address for network 'bridge'.
[INFO] *        IP address [ <no value> ] on Docker network [ bridge ]
[INFO] ************************************************************************
```

Unable to retrieve network warning:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32817 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32816 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[WARNING] Unable to retrieve container networks.
[INFO] ************************************************************************
```

Debug turned on:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To rebuild the Docker image and restart the container, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *
[INFO] *    Liberty container port information:
[INFO] *        Internal container HTTP port [ 9080 ] is mapped to Docker host port [ 32837 ]
[INFO] *        Internal container HTTPS port [ 9443 ] is mapped to Docker host port [ 32836 ]
[INFO] *        Liberty debug port mapped to Docker host port: [ 7777 ]
[INFO] *        
[INFO] *    Docker network information:
[INFO] *        Container name: [ liberty-dev ]
[DEBUG] execDocker, timeout=10, cmd=docker inspect -f '{{.NetworkSettings.Networks}}' liberty-dev
[DEBUG] execDocker, timeout=10, cmd=docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' liberty-dev
[INFO] *        IP address [ 172.17.0.3 ] on Docker network [ bridge ]
[INFO] ************************************************************************
```