### PR TITLE
Fix finding of available port on Windows

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1966,32 +1966,29 @@ public abstract class DevUtil {
         ServerSocket serverSocket = null;
         while (portToTry < 65535) {
             try {
-                serverSocket = new ServerSocket();
-                serverSocket.setReuseAddress(false);
-                // try binding to the loopback address at the port to try
-                serverSocket.bind(new InetSocketAddress(InetAddress.getByName(null), portToTry), 1);
+                // try binding to the portToTry
+                serverSocket = new ServerSocket(portToTry);
                 return serverSocket.getLocalPort();
             } catch (IOException e) {
                 if (serverSocket != null) {
-                    if (isDebugPort) {
-                        // if binding failed, try binding to a random port
-                        serverSocket.bind(null, 1);
-                        int availablePort = serverSocket.getLocalPort();
-                        if (portToTry == preferredPort) {
-                            warn("The debug port " + preferredPort + " is not available.  Using " + availablePort
-                                    + " as the debug port instead.");
-                        } else {
-                            debug("The previous debug port " + alternativeDebugPort + " is no longer available.  Using "
-                                    + availablePort + " as the debug port instead.");
-                        }
-                        alternativeDebugPort = availablePort;
-                        return availablePort;
+                    serverSocket.close();
+                }
+                if (isDebugPort) {
+                    // if binding failed, try binding to a random port
+                    serverSocket = new ServerSocket(0);
+                    int availablePort = serverSocket.getLocalPort();
+                    if (portToTry == preferredPort) {
+                        warn("The debug port " + preferredPort + " is not available.  Using " + availablePort
+                                + " as the debug port instead.");
                     } else {
-                        debug("findAvailablePort found port is in use: " + portToTry);
-                        ++portToTry;
+                        debug("The previous debug port " + alternativeDebugPort + " is no longer available.  Using "
+                                + availablePort + " as the debug port instead.");
                     }
+                    alternativeDebugPort = availablePort;
+                    return availablePort;
                 } else {
-                    throw new IOException("Could not create a server socket.", e);
+                    debug("findAvailablePort found port is in use: " + portToTry);
+                    ++portToTry;
                 }
             } finally {
                 if (serverSocket != null) {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -135,9 +135,7 @@ public class DevUtilTest extends BaseDevUtilTest {
         ServerSocket serverSocket = null;
         ServerSocket serverSocket2 = null;
         try {
-            serverSocket = new ServerSocket();
-            serverSocket.setReuseAddress(false);
-            serverSocket.bind(new InetSocketAddress(InetAddress.getByName(null), availablePort), 1);
+            serverSocket = new ServerSocket(availablePort);
 
             // previous port is bound, so calling findAvailablePort again should get another port
             int availablePort2 = util.findAvailablePort(preferredPort, true);
@@ -155,9 +153,7 @@ public class DevUtilTest extends BaseDevUtilTest {
             assertEquals(availablePort2, availablePort3);
 
             // bind to the previous port
-            serverSocket2 = new ServerSocket();
-            serverSocket2.setReuseAddress(false);
-            serverSocket2.bind(new InetSocketAddress(InetAddress.getByName(null), availablePort2), 1);
+            serverSocket2 = new ServerSocket(availablePort2);
 
             // previous port is now bound, so calling findAvailablePort again should get another port
             int availablePort4 = util.findAvailablePort(preferredPort, true);


### PR DESCRIPTION
Seems the loopback address parts are not applicable to ports being used by Docker on Windows.  Changed it to be more generic.

Fixes https://github.com/OpenLiberty/ci.maven/issues/1033