### PR TITLE
Fix problem with resolving Liberty predefined server dir properties

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -455,7 +455,7 @@ public abstract class ServerFeatureUtil {
             while (m.find()) {
                 String variable = m.group(1);
                 
-                String propertyValue = properties.getProperty(variable, "\\$\\{" + variable + "\\}");
+                String propertyValue = properties.getProperty(variable, "${" + variable + "}");
                 
                 // Remove encapsulating ${} characters and validate that a valid liberty directory property was configured
                 propertyValue = removeEncapsulatingEnvVarSyntax(propertyValue, properties); 


### PR DESCRIPTION
Partial fix for https://github.com/OpenLiberty/ci.maven/issues/1039

This fix handles references to predefined Liberty server directory properties in the server.xml include location. It also eliminates the "Illegal group reference" error for all cases. For variables that are not resolved, a warning is logged.

The following are still not handled:

- resolving variables defined in server.xml (or files it includes)
- resolving references to env properties
- resolving references to server.env properties