### PR TITLE
Set DOCKER_BUILDKIT=0 environment var for docker build and run on Mac and Windows

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1097,7 +1097,7 @@ public abstract class DevUtil {
 
     private void startContainer() {
         try {
-            if (System.getProperty("os.name").equalsIgnoreCase("linux")) {
+            if (OSUtil.isLinux()) {
                 // Allow the server to write to the log files. If we don't create it here docker daemon will create it as root.
                 runCmd("mkdir -p " + serverDirectory + "/logs");
             }
@@ -1128,7 +1128,7 @@ public abstract class DevUtil {
     private Process getRunProcess(String command) throws IOException {
         ProcessBuilder processBuilder = new ProcessBuilder();
         processBuilder.command(getCommandTokens(command));
-        if (!System.getProperty("os.name").equalsIgnoreCase("linux")){
+        if (!OSUtil.isLinux()){
             Map<String, String> env = processBuilder.environment();
             if (!env.keySet().contains("DOCKER_BUILDKIT")) { // don't touch if already set
                 env.put("DOCKER_BUILDKIT", "0"); // must set 0 on Windows VMs
@@ -1533,7 +1533,7 @@ public abstract class DevUtil {
     }
 
     private String getUserId() {
-        if (System.getProperty("os.name").equalsIgnoreCase("linux")) {
+        if (OSUtil.isLinux()) {
             try {
                 String id = runCmd("id -u");
                 if (id != null) {
@@ -2966,7 +2966,7 @@ public abstract class DevUtil {
                         // re-enable debug variables in server.env
                         enableServerDebug(false);
                     }
-                    if (container && System.getProperty("os.name").equalsIgnoreCase("linux")) {
+                    if (container && OSUtil.isLinux()) {
                         info("Restarting the container for this change to take effect.");
                         // Allow a 1 second grace period to replace the file in case the user changes the file with a script or a tool like vim.
                         try {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/OSUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/OSUtil.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2018, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package io.openliberty.tools.common.plugins.util;
 
 public class OSUtil {
-    
+
     /**
      * Determines if the current OS is a Windows OS.
      * 
@@ -26,6 +26,16 @@ public class OSUtil {
     public static boolean isWindows() {
         String osName = System.getProperty("os.name", "unknown").toLowerCase();
         return osName.indexOf("windows") >= 0;
+    }
+
+    /**
+     * Determines if the current OS is a Linux OS.
+     * 
+     * @return true if running on Linux, false otherwise
+     */
+    public static boolean isLinux() {
+        String osName = System.getProperty("os.name", "unknown").toLowerCase();
+        return osName.indexOf("linux") >= 0;
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1045
Also increase docker command timeouts from 10s to 20s except server stop from 30s to 40s. VMs can be slower than physical machines. 