### PR TITLE
Fix when to display features warning message

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -339,9 +339,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     private Set<WatchKey> dockerfileDirectoriesWatchKeys = new HashSet<WatchKey>();
     private Set<FileAlterationObserver> dockerfileDirectoriesFileObservers = new HashSet<FileAlterationObserver>();
     private final JavaCompilerOptions compilerOptions;
-    private boolean shownFeaturesShWarning = false;
     private final String mavenCacheLocation;
     private AtomicBoolean externalContainerShutdown;
+    private AtomicBoolean shownFeaturesShWarning;
     protected AtomicBoolean hasFeaturesSh;
 
     public DevUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory, File projectDirectory,
@@ -397,6 +397,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         this.keepTempDockerfile = keepTempDockerfile;
         this.mavenCacheLocation = mavenCacheLocation;
         this.externalContainerShutdown = new AtomicBoolean(false);
+        this.shownFeaturesShWarning = new AtomicBoolean(false);
         this.hasFeaturesSh = new AtomicBoolean(false);
     }
 
@@ -927,6 +928,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     protected void detectFeaturesSh(List<String> dockerfileLines) {
+        // Reset features.sh warning flag
+        shownFeaturesShWarning.set(false);
+
         final String FEATURES_SH_COMMAND_LOWERCASE = "run features.sh";
         for (int i=0; i<dockerfileLines.size(); i++) {
             String line = dockerfileLines.get(i);
@@ -937,6 +941,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 return;
             }
         }
+        // if not detected, reset to false in case the Dockerfile is being rebuilt
+        debug("Did not find RUN features.sh command.");
+        hasFeaturesSh.set(false);
     }
 
     protected void processCopyLines(List<String> dockerfileLines, String buildContext) throws PluginExecutionException {
@@ -1254,9 +1261,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                             false);
 
                     // Look for features not available message in server output if features.sh was not defined in Dockerfile
-                    if (!hasFeaturesSh.get() && !shownFeaturesShWarning) {
+                    if (!hasFeaturesSh.get() && !shownFeaturesShWarning.get()) {
                         String errMsg = "Feature definitions were not found in the container. To install features to the container, specify 'RUN features.sh' in your Dockerfile. For an example of how to configure a Dockerfile, see https://github.com/OpenLiberty/ci.docker";
-                        shownFeaturesShWarning = alertOnServerError(line, "CWWKF0001E", errMsg, errMsg, true);
+                        shownFeaturesShWarning.set(alertOnServerError(line, "CWWKF0001E", errMsg, errMsg, true));
                     }
                 }
             }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilPrepareDockerfileTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilPrepareDockerfileTest.java
@@ -266,13 +266,19 @@ public class DevUtilPrepareDockerfileTest extends BaseDevUtilTest {
         test.add("FROM open-liberty");
         test.add("RUN configure.sh");
         util.detectFeaturesSh(test);
-        assertEquals(false, util.hasFeaturesSh.get());
+        assertEquals("Should not have detected features.sh", false, util.hasFeaturesSh.get());
 
-        test = new ArrayList<String>();
+        test.clear();
         test.add("FROM open-liberty");
         test.add("RUN features.sh");
         util.detectFeaturesSh(test);
-        assertEquals(true, util.hasFeaturesSh.get());
+        assertEquals("Should have detected features.sh", true, util.hasFeaturesSh.get());
+
+        test.clear();
+        test.add("FROM open-liberty");
+        test.add("RUN configure.sh");
+        util.detectFeaturesSh(test);
+        assertEquals("Should have resetted to not detect features.sh", false, util.hasFeaturesSh.get());
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilPrepareDockerfileTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilPrepareDockerfileTest.java
@@ -260,4 +260,19 @@ public class DevUtilPrepareDockerfileTest extends BaseDevUtilTest {
         assertEquals(expectedDockerfileLines, dockerfileLines);
     }
 
+    @Test
+    public void testDetectFeaturesSh() throws Exception {
+        List<String> test = new ArrayList<String>();
+        test.add("FROM open-liberty");
+        test.add("RUN configure.sh");
+        util.detectFeaturesSh(test);
+        assertEquals(false, util.hasFeaturesSh.get());
+
+        test = new ArrayList<String>();
+        test.add("FROM open-liberty");
+        test.add("RUN features.sh");
+        util.detectFeaturesSh(test);
+        assertEquals(true, util.hasFeaturesSh.get());
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1061

- Only display RUN features.sh warning message if all of these conditions are met: server still is starting up, Dockerfile does not have `RUN features.sh`, and the message has not been displayed before during this startup session.