### PR TITLE
Do not add current classloader to compile classpath

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3657,20 +3657,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * @throws IOException unable to resolve canonical path
      */
     protected Set<File> getClassPath(List<String> artifactPaths, List<File> outputDirs) throws IOException {
-        List<URL> urls = new ArrayList<>();
-        ClassLoader c = Thread.currentThread().getContextClassLoader();
-        while (c != null) {
-            if (c instanceof URLClassLoader) {
-                urls.addAll(Arrays.asList(((URLClassLoader) c).getURLs()));
-            }
-            c = c.getParent();
-        }
-
         Set<String> parsedFiles = new HashSet<>();
         Deque<String> toParse = new ArrayDeque<>();
-        for (URL url : urls) {
-            toParse.add(new File(url.getPath()).getCanonicalPath());
-        }
 
         for (String artifactPath : artifactPaths) {
             toParse.add(new File(artifactPath).getCanonicalPath());


### PR DESCRIPTION
When recompiling in dev mode for Maven, do not include the current classloader (of Liberty Maven plugin) for determining the compile classpath.  Instead, it should only use the artifacts defined in the Maven project for the classpath.

Fixes https://github.com/OpenLiberty/ci.maven/issues/1081