### PR TITLE
Add call to regenerate the feature list when recreating and restarting the server

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1573,6 +1573,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     public abstract void libertyDeploy() throws PluginExecutionException;
 
+    public abstract void libertyGenerateFeatures() throws PluginExecutionException;
+
     /**
      * Install features in regular dev mode. This method should not be used in container mode.
      * @throws PluginExecutionException
@@ -1617,6 +1619,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         // suppress install feature warning
         System.setProperty(SKIP_BETA_INSTALL_WARNING, Boolean.TRUE.toString());
         libertyCreate();
+        libertyGenerateFeatures();
         // Skip installing features on container during restart, since the Dockerfile should have 'RUN features.sh'
         if (!container) {
             libertyInstallFeature();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2020.
+ * (C) Copyright IBM Corporation 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This restart is caused by some of the Liberty config files being changed.