### PR TITLE
Use common parent directory when mounting loose application in container

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -120,7 +120,6 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     private static final String[] DEFAULT_COMPILER_OPTIONS = new String[] { "-g", "-parameters" };
     private static final int LIBERTY_DEFAULT_HTTP_PORT = 9080;
     private static final int LIBERTY_DEFAULT_HTTPS_PORT = 9443;
-    private static final int LIBERTY_DEFAULT_DEBUG_PORT = 7777;
     private static final int DOCKER_TIMEOUT = 20; // seconds
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1371,15 +1371,14 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     protected static File getLongestCommonDir(File dir1, File dir2) {
         // based on https://stackoverflow.com/a/54596165
         Path relativePath = dir1.toPath().relativize(dir2.toPath()).normalize();
-        if (relativePath == null || relativePath.toString().isEmpty()) {
-            // paths are equal
-            return dir1;
-        }
         while (relativePath != null && !relativePath.endsWith("..")) {
             relativePath = relativePath.getParent();
         }
-        Path result = dir1.toPath().resolve(relativePath).normalize();
-        return result.toFile();
+        if (relativePath == null || relativePath.toString().isEmpty()) {
+            return dir1;
+        } else {
+            return dir1.toPath().resolve(relativePath).normalize().toFile();
+        }
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -485,4 +485,24 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertArrayEquals(null, DevUtil.parseNetworks(""));
     }
 
+    @Test
+    public void testLongestCommonDir() throws Exception {
+        // These Unix style paths should also work with Windows if they are all on the same drive
+        assertEquals("Same paths", new File("/a/b/c"), DevUtil.getLongestCommonDir(new File("/a/b/c"), new File("/a/b/c")));
+
+        assertEquals("dir1 should be subdirectory of dir2", new File("/a/b"), DevUtil.getLongestCommonDir(new File("/a/b"), new File("/a/b/c")));
+        assertEquals("dir1 should be subdirectory of dir2", new File("/a"), DevUtil.getLongestCommonDir(new File("/a"), new File("/a/b/c/d")));
+        assertEquals("dir1 should be subdirectory of dir2", new File("/"), DevUtil.getLongestCommonDir(new File("/"), new File("/a/b/c/d")));
+
+        assertEquals("dir2 should be subdirectory of dir1", new File("/a/b"), DevUtil.getLongestCommonDir(new File("/a/b/c"), new File("/a/b")));
+        assertEquals("dir2 should be subdirectory of dir1", new File("/a"), DevUtil.getLongestCommonDir(new File("/a/b/c/d"), new File("/a")));
+        assertEquals("dir2 should be subdirectory of dir1", new File("/"), DevUtil.getLongestCommonDir(new File("/a/b/c/d"), new File("/")));
+
+        assertEquals("Sibling directories", new File("/a/b/c"), DevUtil.getLongestCommonDir(new File("/a/b/c/1"), new File("/a/b/c/2")));
+
+        assertEquals("Nested sibling directories", new File("/a/b/c"), DevUtil.getLongestCommonDir(new File("/a/b/c/1/2/3"), new File("/a/b/c/4/5/6")));
+
+        assertEquals("Parent should be the drive root", new File("/"), DevUtil.getLongestCommonDir(new File("/a/b/c"), new File("/d/e/f")));
+    }
+
 }


### PR DESCRIPTION
In a multi module project, if the projectDirectory and the multiModuleProjectDirectory are different, use the longest common directory as the project root for mounting the loose application files to container.