### PR TITLE
Multi-module support for hot source compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,15 +65,5 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.6.3</version>
         </dependency>
-		<dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-		<dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>3.5.0</version>
-        </dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,5 +65,15 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.6.3</version>
         </dependency>
+		<dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+		<dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.5.0</version>
+        </dependency>
 	</dependencies>
 </project>

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -1,0 +1,87 @@
+package io.openliberty.tools.common.plugins.util;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+public class UpstreamProject {
+
+    private File buildFile;
+    private List<String> compileArtifacts;
+    private File sourceDirectory;
+    private File outputDirectory;
+    private String projectName;
+    private List<File> resourceDirs;
+    private HashMap<File, Boolean> resourceMap;
+
+    // src/main/java file changes
+    public Collection<File> recompileJavaSources;
+    public Collection<File> deleteJavaSources;
+    public Collection<File> failedCompilationJavaSources;
+
+    /**
+     * Defines an upstream project for supporting multi-module projects
+     * 
+     * @param buildFile        pom.xml
+     * @param projectName      project name (artifactId)
+     * @param compileArtifacts compileArtifacts of project
+     * @param sourceDirectory  src/main/java dir
+     * @param outputDirectory  output dir
+     * @param resourceDirs     resource directories
+     */
+    public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts, File sourceDirectory,
+            File outputDirectory, List<File> resourceDirs) {
+        this.buildFile = buildFile;
+        this.projectName = projectName;
+        this.compileArtifacts = compileArtifacts;
+        this.sourceDirectory = sourceDirectory;
+        this.outputDirectory = outputDirectory;
+        this.resourceDirs = resourceDirs;
+
+        // init src/main/java file tracking collections
+        this.recompileJavaSources = new HashSet<File>();
+        this.deleteJavaSources = new HashSet<File>();
+        this.failedCompilationJavaSources = new HashSet<File>();
+
+        // resource map
+        this.resourceMap = new HashMap<File, Boolean>();
+    }
+
+    public HashMap<File, Boolean> getResourceMap() {
+        return this.resourceMap;
+    }
+
+    public void setResourceMap(HashMap<File, Boolean> resourceMap) {
+        this.resourceMap = resourceMap;
+    }
+
+    public String getProjectName() {
+        return this.projectName;
+    }
+
+    public File getBuildFile() {
+        return this.buildFile;
+    }
+
+    public void setCompileArtifacts(List<String> artifacts) {
+        this.compileArtifacts = artifacts;
+    }
+
+    public List<String> getCompileArtifacts() {
+        return this.compileArtifacts;
+    }
+
+    public File getSourceDirectory() {
+        return this.sourceDirectory;
+    }
+
+    public File getOutputDirectory() {
+        return this.outputDirectory;
+    }
+
+    public List<File> getResourceDirs() {
+        return this.resourceDirs;
+    }
+}

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -96,11 +96,19 @@ public class BaseDevUtilTest {
         @Override
         public ServerTask getServerTask() throws IOException {
             // not needed for tests
-            return null;            
+            return null;
         }
 
         @Override
-        public boolean recompileBuildFile(File buildFile, List<String> compileArtifactPaths, List<String> testArtifactPaths, ThreadPoolExecutor executor) {
+        public boolean recompileBuildFile(File buildFile, List<String> compileArtifactPaths,
+                List<String> testArtifactPaths, ThreadPoolExecutor executor) {
+            // not needed for tests
+            return false;
+        }
+
+        @Override
+        public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
+                ThreadPoolExecutor executor) throws PluginExecutionException {
             // not needed for tests
             return false;
         }


### PR DESCRIPTION
Adds support for hot compilation of multi module projects. Tracks upstream projects and supports the following scenarios:
- Source compilation of upstream projects
   - change in source code triggers hot compilation of that class. If successful, tries compiling any projects with compilation failures
   - on first watch loop, skips attempting to recompile projects with compilation failures (to avoid multiple compilations if a user starts dev mode with some compile errors)
   - in the multi-module scenario messages will specify the module they relate to, ie. `guide-maven-multimodules-jar source compilation was successful.`

- Watching `pom.xml` of upstream projects
   - updates the classpath used for compilation for the corresponding project
   - tries recompiling any projects with compilation failures (in case adding a dependency to the `pom.xml` solved some compilation errors)

- Watching resource directories of upstream projects
   - supports modifying/deleting resource file, and copying it to the corresponding `target/classes` directory 
   - supports adding a resource directory to an upstream project after dev mode has been started