### PR TITLE
Support hot compilation of and running tests for multi module Maven projects

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4358,10 +4358,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * @return true if this is a multi module project, false if not
      */
     private boolean isMultiModuleProject() {
-        if (upstreamProjects != null && !upstreamProjects.isEmpty()) {
-            return true;
-        }
-        return false;
+        return (upstreamProjects != null && !upstreamProjects.isEmpty());
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -200,12 +200,15 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * @param buildFile
      * @param compileArtifactPaths
      * @param testArtifactPaths
+     * @param redeployCheck        Whether to redeploy the application if changes in
+     *                             the dependencies are detected
      * @param executor             The thread pool executor
      * @return true if the compile artifact paths are updated
      * @throws PluginExecutionException
      */
     public abstract boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
-            List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException;
+            List<String> testArtifactPaths, boolean redeployCheck, ThreadPoolExecutor executor)
+            throws PluginExecutionException;
 
     /**
      * Run the unit tests
@@ -2469,7 +2472,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             // check for upstream projects
             if (isMultiModuleProject()) {
                 for (UpstreamProject p : upstreamProjects) {
-                    updateArtifactPaths(p.getBuildFile(), p.getCompileArtifacts(), p.getTestArtifacts(), executor);
+                    updateArtifactPaths(p.getBuildFile(), p.getCompileArtifacts(), p.getTestArtifacts(), false, executor);
                     // watch src/main/java dir
                     if (p.getSourceDirectory().exists()) {
                         registerAll(p.getSourceDirectory().getCanonicalFile().toPath(), executor);
@@ -3295,7 +3298,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     debug("Change detected in: " + project.getBuildFile() + ". Updating compile artifact paths.");
                     // when an upstream project build file changes, get the updated artifact paths
                     boolean updatedArtifactPaths = updateArtifactPaths(project.getBuildFile(),
-                            project.getCompileArtifacts(), project.getTestArtifacts(), executor);
+                            project.getCompileArtifacts(), project.getTestArtifacts(), true, executor);
                     if (updatedArtifactPaths) {
                         // trigger java source recompile of all projects if there are compilation errors
                         // in this project

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -19,6 +19,8 @@ public class UpstreamProject {
     private List<File> resourceDirs;
     private HashMap<File, Boolean> resourceMap;
     private boolean skipUTs;
+    private boolean skipTests;
+    private boolean skipITs;
 
     // src/main/java file changes
     public Collection<File> recompileJavaSources;
@@ -43,11 +45,13 @@ public class UpstreamProject {
      * @param testSourceDirectory src/test/java dir
      * @param testOutputDirectory test output dir
      * @param resourceDirs        resource directories
+     * @param skipTests
      * @param skipUTs
+     * @param skipITs
      */
     public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
             List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,
-            File testOutputDirectory, List<File> resourceDirs, boolean skipUTs) {
+            File testOutputDirectory, List<File> resourceDirs, boolean skipTests, boolean skipUTs, boolean skipITs) {
         this.buildFile = buildFile;
         this.projectName = projectName;
         this.compileArtifacts = compileArtifacts;
@@ -57,7 +61,9 @@ public class UpstreamProject {
         this.testSourceDirectory = testSourceDirectory;
         this.testOutputDirectory = testOutputDirectory;
         this.resourceDirs = resourceDirs;
+        this.skipTests = skipTests;
         this.skipUTs = skipUTs;
+        this.skipITs = skipITs;
 
         // init src/main/java file tracking collections
         this.recompileJavaSources = new HashSet<File>();
@@ -118,7 +124,15 @@ public class UpstreamProject {
         return this.resourceDirs;
     }
 
+    public boolean skipTests() {
+        return this.skipTests;
+    }
+
     public boolean skipUTs() {
         return this.skipUTs;
+    }
+
+    public boolean skipITs() {
+        return this.skipITs;
     }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -18,6 +18,7 @@ public class UpstreamProject {
     private String projectName;
     private List<File> resourceDirs;
     private HashMap<File, Boolean> resourceMap;
+    private boolean skipUTs;
 
     // src/main/java file changes
     public Collection<File> recompileJavaSources;
@@ -41,10 +42,11 @@ public class UpstreamProject {
      * @param testSourceDirectory src/test/java dir
      * @param testOutputDirectory test output dir
      * @param resourceDirs        resource directories
+     * @param skipUTs
      */
     public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
             List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,
-            File testOutputDirectory, List<File> resourceDirs) {
+            File testOutputDirectory, List<File> resourceDirs, boolean skipUTs) {
         this.buildFile = buildFile;
         this.projectName = projectName;
         this.compileArtifacts = compileArtifacts;
@@ -54,6 +56,7 @@ public class UpstreamProject {
         this.testSourceDirectory = testSourceDirectory;
         this.testOutputDirectory = testOutputDirectory;
         this.resourceDirs = resourceDirs;
+        this.skipUTs = skipUTs;
 
         // init src/main/java file tracking collections
         this.recompileJavaSources = new HashSet<File>();
@@ -111,5 +114,9 @@ public class UpstreamProject {
 
     public List<File> getResourceDirs() {
         return this.resourceDirs;
+    }
+
+    public boolean skipUTs() {
+        return this.skipUTs;
     }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -45,9 +45,9 @@ public class UpstreamProject {
      * @param testSourceDirectory src/test/java dir
      * @param testOutputDirectory test output dir
      * @param resourceDirs        resource directories
-     * @param skipTests
-     * @param skipUTs
-     * @param skipITs
+     * @param skipTests           whether to skip tests for this project
+     * @param skipUTs             whether to skip unit tests for this project
+     * @param skipITs             whether to skip integration tests for this project
      */
     public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
             List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -29,6 +29,7 @@ public class UpstreamProject {
     public Collection<File> recompileJavaTests;
     public Collection<File> deleteJavaTests;
     public Collection<File> failedCompilationJavaTests;
+    public boolean triggerJavaTestRecompile;
 
     /**
      * Defines an upstream project for supporting multi-module projects
@@ -67,6 +68,7 @@ public class UpstreamProject {
         this.recompileJavaTests = new HashSet<File>();
         this.deleteJavaTests = new HashSet<File>();
         this.failedCompilationJavaTests = new HashSet<File>();
+        this.triggerJavaTestRecompile = false;
 
         // resource map
         this.resourceMap = new HashMap<File, Boolean>();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -10,8 +10,11 @@ public class UpstreamProject {
 
     private File buildFile;
     private List<String> compileArtifacts;
+    private List<String> testArtifacts;
     private File sourceDirectory;
     private File outputDirectory;
+    private File testSourceDirectory;
+    private File testOutputDirectory;
     private String projectName;
     private List<File> resourceDirs;
     private HashMap<File, Boolean> resourceMap;
@@ -21,29 +24,46 @@ public class UpstreamProject {
     public Collection<File> deleteJavaSources;
     public Collection<File> failedCompilationJavaSources;
 
+    // src/test/java file changes
+    public Collection<File> recompileJavaTests;
+    public Collection<File> deleteJavaTests;
+    public Collection<File> failedCompilationJavaTests;
+
     /**
      * Defines an upstream project for supporting multi-module projects
      * 
-     * @param buildFile        pom.xml
-     * @param projectName      project name (artifactId)
-     * @param compileArtifacts compileArtifacts of project
-     * @param sourceDirectory  src/main/java dir
-     * @param outputDirectory  output dir
-     * @param resourceDirs     resource directories
+     * @param buildFile           pom.xml
+     * @param projectName         project name (artifactId)
+     * @param compileArtifacts    compileArtifacts of project
+     * @param testArtifacts       testArtifacts of project
+     * @param sourceDirectory     src/main/java dir
+     * @param outputDirectory     output dir
+     * @param testSourceDirectory src/test/java dir
+     * @param testOutputDirectory test output dir
+     * @param resourceDirs        resource directories
      */
-    public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts, File sourceDirectory,
-            File outputDirectory, List<File> resourceDirs) {
+    public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
+            List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,
+            File testOutputDirectory, List<File> resourceDirs) {
         this.buildFile = buildFile;
         this.projectName = projectName;
         this.compileArtifacts = compileArtifacts;
+        this.testArtifacts = testArtifacts;
         this.sourceDirectory = sourceDirectory;
         this.outputDirectory = outputDirectory;
+        this.testSourceDirectory = testSourceDirectory;
+        this.testOutputDirectory = testOutputDirectory;
         this.resourceDirs = resourceDirs;
 
         // init src/main/java file tracking collections
         this.recompileJavaSources = new HashSet<File>();
         this.deleteJavaSources = new HashSet<File>();
         this.failedCompilationJavaSources = new HashSet<File>();
+
+        // init src/test/java file tracking collections
+        this.recompileJavaTests = new HashSet<File>();
+        this.deleteJavaTests = new HashSet<File>();
+        this.failedCompilationJavaTests = new HashSet<File>();
 
         // resource map
         this.resourceMap = new HashMap<File, Boolean>();
@@ -65,12 +85,12 @@ public class UpstreamProject {
         return this.buildFile;
     }
 
-    public void setCompileArtifacts(List<String> artifacts) {
-        this.compileArtifacts = artifacts;
-    }
-
     public List<String> getCompileArtifacts() {
         return this.compileArtifacts;
+    }
+
+    public List<String> getTestArtifacts() {
+        return this.testArtifacts;
     }
 
     public File getSourceDirectory() {
@@ -79,6 +99,14 @@ public class UpstreamProject {
 
     public File getOutputDirectory() {
         return this.outputDirectory;
+    }
+
+    public File getTestSourceDirectory() {
+        return this.testSourceDirectory;
+    }
+
+    public File getTestOutputDirectory() {
+        return this.testOutputDirectory;
     }
 
     public List<File> getResourceDirs() {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -108,7 +108,7 @@ public class BaseDevUtilTest {
 
         @Override
         public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
-                ThreadPoolExecutor executor) throws PluginExecutionException {
+                List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException {
             // not needed for tests
             return false;
         }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -36,7 +36,7 @@ public class BaseDevUtilTest {
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null, resourceDirs, hotTests, skipTests, 
-                  false, false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null);
+                  false, false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null, null);
         }
 
         @Override
@@ -121,9 +121,9 @@ public class BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs, File buildFile) {
+                boolean forceSkipUTs, File buildFile, String projectName) {
             // not needed for tests
-            
+
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -36,7 +36,7 @@ public class BaseDevUtilTest {
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null, resourceDirs, hotTests, skipTests, 
-                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null);
+                  false, false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null);
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -108,7 +108,8 @@ public class BaseDevUtilTest {
 
         @Override
         public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
-                List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException {
+                List<String> testArtifactPaths, boolean redeployCheck, ThreadPoolExecutor executor)
+                throws PluginExecutionException {
             // not needed for tests
             return false;
         }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -121,7 +121,7 @@ public class BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs) {
+                boolean forceSkipUTs, File buildFile) {
             // not needed for tests
             
         }
@@ -139,12 +139,12 @@ public class BaseDevUtilTest {
         }
 
         @Override
-        public void runUnitTests() throws PluginScenarioException, PluginExecutionException {
+        public void runUnitTests(File buildFile) throws PluginScenarioException, PluginExecutionException {
             // not needed for tests
         }
 
         @Override
-        public void runIntegrationTests() throws PluginScenarioException, PluginExecutionException {
+        public void runIntegrationTests(File buildFile) throws PluginScenarioException, PluginExecutionException {
             // not needed for tests
         }
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -36,7 +36,7 @@ public class BaseDevUtilTest {
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null, resourceDirs, hotTests, skipTests, 
-                  false, false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null, null);
+                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null, null);
         }
 
         @Override
@@ -121,7 +121,7 @@ public class BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs, File buildFile, String projectName) {
+                boolean forceSkipTests, boolean forceSkipUTs, boolean forceSkipITs, File buildFile, String projectName) {
             // not needed for tests
 
         }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -37,7 +38,7 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs) {
+                boolean forceSkipUTs, File buildFile) {
             counter++;
         }
     }
@@ -50,11 +51,11 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
         final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(1, true));
 
         // manualInvocation=false should not start a thread
-        util.runTestThread(false, executor, -1, false, false);
+        util.runTestThread(false, executor, -1, false, false, null);
         assertEquals(0, executor.getPoolSize());
 
         // manualInvocation=true should start a thread
-        util.runTestThread(false, executor, -1, false, true);
+        util.runTestThread(false, executor, -1, false, true, null);
         assertEquals(1, executor.getPoolSize());
         
         // shutdown executor
@@ -73,7 +74,7 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
         final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(1, true));
 
         // manualInvocation=false and hotTests=true should start a thread
-        util.runTestThread(false, executor, -1, false, false);
+        util.runTestThread(false, executor, -1, false, false, null);
         assertEquals(1, executor.getPoolSize());
 
         // shutdown executor

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
@@ -40,7 +40,7 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs, File buildFile, String projectName) {
+                boolean forceSkipTests, boolean forceSkipUTs, boolean forceSkipITs, File buildFile, String projectName) {
             counter++;
         }
     }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
@@ -40,7 +40,7 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
 
         @Override
         public void runTests(boolean waitForApplicationUpdate, int messageOccurrences, ThreadPoolExecutor executor,
-                boolean forceSkipUTs, File buildFile) {
+                boolean forceSkipUTs, File buildFile, String projectName) {
             counter++;
         }
     }


### PR DESCRIPTION
Adds support for hot compilation of test directories for multi module Maven projects, and supports running tests across all modules.
- Dev mode watches the test directories of the different modules, and on save will recompile. On a successful recompile, dev mode will try to recompile any other failing classes within the same module. 
- On Enter, all tests across all modules will be run. The `upstreamProjects` object is now a List instead of a Set, to ensure that when tests are run for all modules, they will match the reactor build order. 
- If the `hotTests` flag is enabled, only the tests corresponding to the module changed will be run (the `runTests` method now accepts build file(s), and will run tests against the build file(s) specified). If the `hotTests` flag is enabled, handle the initial run of tests after java compilation in the `processJavaCompilation` method. 
- Honour the values for `skipTests`, `skipUTs` or `skipITs` that are configured via the pom.xml in any of the upstream modules. Any values specified via command line (`-DskipITs`) will take precedence. As with regular dev mode, unit tests will always be skipped for `ear` Maven modules. 