### PR TITLE
Support adding a new test dir for an upstream module

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -32,6 +32,7 @@ public class UpstreamProject {
     public Collection<File> deleteJavaTests;
     public Collection<File> failedCompilationJavaTests;
     public boolean triggerJavaTestRecompile;
+    public boolean testSourceDirRegistered;
 
     /**
      * Defines an upstream project for supporting multi-module projects
@@ -75,6 +76,7 @@ public class UpstreamProject {
         this.deleteJavaTests = new HashSet<File>();
         this.failedCompilationJavaTests = new HashSet<File>();
         this.triggerJavaTestRecompile = false;
+        this.testSourceDirRegistered = false;
 
         // resource map
         this.resourceMap = new HashMap<File, Boolean>();


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1164

Supports adding a new test directory for an upstream module once dev mode has started. This applies only to the multi-module Maven scenario.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>