### PR TITLE
Add env var to allow remote debug

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1468,7 +1468,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             }
             command.append(" -p " + hostDebugPort + ":" + containerDebugPort);
             // set environment variables in the container to ensure debug mode does not suspend the server, and to enable a custom debug port to be used
-            command.append(" -e WLP_DEBUG_SUSPEND=n -e WLP_DEBUG_ADDRESS=" + containerDebugPort);
+            // and to allow remote debugging into the container
+            command.append(" -e WLP_DEBUG_SUSPEND=n -e WLP_DEBUG_ADDRESS=" + containerDebugPort + " -e WLP_DEBUG_REMOTE=y");
         }
 
         // mount potential directories containing .war.xml from devc specific folder - override /config/apps and /config/dropins


### PR DESCRIPTION
When devc issues the `docker run` command, append [WLP_DEBUG_REMOTE environment var](https://github.com/OpenLiberty/open-liberty/blob/2fd4a880754c37a988c5ed9ac4f1ea5988e465d6/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server#L58) as WLP_DEBUG_REMOTE=y to allow remote debugging on newer Java versions such as 11.

Fixes https://github.com/OpenLiberty/ci.maven/issues/1161