### PR TITLE
Dev mode should search for only the start/update code in logs

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -90,8 +90,8 @@ import io.openliberty.tools.ant.ServerTask;
 public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     private static final String START_SERVER_MESSAGE_PREFIX = "CWWKF0011I:";
-    private static final String START_APP_MESSAGE_REGEXP = "CWWKZ0001I.*";
-    private static final String UPDATED_APP_MESSAGE_REGEXP = "CWWKZ0003I.*";
+    private static final String START_APP_MESSAGE_REGEXP = "CWWKZ0001I:";
+    private static final String UPDATED_APP_MESSAGE_REGEXP = "CWWKZ0003I:";
     private static final String PORT_IN_USE_MESSAGE_PREFIX = "CWWKO0221E:";
     private static final String WEB_APP_AVAILABLE_MESSAGE_PREFIX = "CWWKT0016I:";
     private static final String LISTENING_ON_PORT_MESSAGE_PREFIX = "CWWKO0219I:";
@@ -450,7 +450,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
             File logFile = getMessagesLogFile(serverTask);
 
-            String regexp = UPDATED_APP_MESSAGE_REGEXP + applicationId;
+            String regexp = UPDATED_APP_MESSAGE_REGEXP;
 
             try {
                 Thread.sleep(500);
@@ -524,7 +524,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     info("Waiting up to " + appStartupTimeout
                             + " seconds to find the application start up or update message...");
                     String startMessage = serverTask.waitForStringInLog(
-                            "(" + START_APP_MESSAGE_REGEXP + "|" + UPDATED_APP_MESSAGE_REGEXP + applicationId + ")",
+                            "(" + START_APP_MESSAGE_REGEXP + "|" + UPDATED_APP_MESSAGE_REGEXP + ")",
                             timeout, logFile);
                     if (startMessage == null) {
                         error("Unable to verify if the application was started after " + appStartupTimeout
@@ -587,7 +587,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             try {
                 ServerTask serverTask = getServerTask();
                 File logFile = getMessagesLogFile(serverTask);
-                String regexp = UPDATED_APP_MESSAGE_REGEXP + applicationId;
+                String regexp = UPDATED_APP_MESSAGE_REGEXP;
                 messageOccurrences = serverTask.countStringOccurrencesInFile(regexp, logFile);
                 debug("Message occurrences before compile: " + messageOccurrences);
             } catch (Exception e) {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1160

Rather than searching for the updated message code + application id in the logs, only search for the code. This will validate that the application has updated in a single module scenario, as it will search for 1  new updated message in log.  This will also validate that the application(s) update in a multi module scenario, as it will check that there is 1+ new updated messages in the log. See the corresponding [waitForUpdatedStringInLog](https://github.com/OpenLiberty/ci.ant/blob/92e3595d552f3e3ebb9c0f726f74d469fc5c2264/src/main/java/io/openliberty/tools/ant/AbstractTask.java#L516-L555) method in ci.ant.

ci.maven and ci.gradle dev mode tests passed locally. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>