### PR TITLE
Dev mode support for multi module compiler options

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -186,13 +186,13 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * @param buildFile
      * @param compileArtifactPaths
      * @param testArtifactPaths
-     * @param executor      The thread pool executor
+     * @param executor             The thread pool executor
      * @throws PluginExecutionException if there was an error when restarting the
      *                                  server
      * @return true if the build file was recompiled with changes
      */
-    public abstract boolean recompileBuildFile(File buildFile, List<String> compileArtifactPaths, List<String> testArtifactPaths, ThreadPoolExecutor executor)
-            throws PluginExecutionException;
+    public abstract boolean recompileBuildFile(File buildFile, List<String> compileArtifactPaths,
+            List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException;
 
     /**
      * Updates the compile artifact paths of the given build file
@@ -348,7 +348,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     private Set<Path> dockerfileDirectoriesTracked = new HashSet<Path>();
     private Set<WatchKey> dockerfileDirectoriesWatchKeys = new HashSet<WatchKey>();
     private Set<FileAlterationObserver> dockerfileDirectoriesFileObservers = new HashSet<FileAlterationObserver>();
-    private final JavaCompilerOptions compilerOptions;
+    private JavaCompilerOptions compilerOptions;
     private final String mavenCacheLocation;
     private AtomicBoolean externalContainerShutdown;
     private AtomicBoolean shownFeaturesShWarning;
@@ -4374,6 +4374,33 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     public String getContainerName() {
         return containerName;
+    }
+
+    /**
+     * Updates the Java compiler options
+     * @param updatedCompilerOptions
+     */
+    public void updateJavaCompilerOptions(JavaCompilerOptions updatedCompilerOptions) {
+        compilerOptions = updatedCompilerOptions;
+    }
+
+    /**
+     * Given a build file returns the corresponding UpstreamProject otherwise
+     * returns null
+     * 
+     * @param buildFile
+     * @return Upstream Project
+     * @throws IOException
+     */
+    public UpstreamProject getUpstreamProject(File buildFile) throws IOException {
+        if (isMultiModuleProject()) {
+            for (UpstreamProject p : upstreamProjects) {
+                if (p.getBuildFile().getCanonicalPath().equals(buildFile.getCanonicalPath())) {
+                    return p;
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -145,4 +145,8 @@ public class UpstreamProject {
     public JavaCompilerOptions getCompilerOptions() {
         return this.compilerOptions;
     }
+
+    public void setCompilerOptions(JavaCompilerOptions compilerOptions) {
+        this.compilerOptions = compilerOptions;
+    }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/UpstreamProject.java
@@ -23,6 +23,7 @@ public class UpstreamProject {
     private boolean skipITs;
 
     // src/main/java file changes
+    private JavaCompilerOptions compilerOptions;
     public Collection<File> recompileJavaSources;
     public Collection<File> deleteJavaSources;
     public Collection<File> failedCompilationJavaSources;
@@ -49,10 +50,12 @@ public class UpstreamProject {
      * @param skipTests           whether to skip tests for this project
      * @param skipUTs             whether to skip unit tests for this project
      * @param skipITs             whether to skip integration tests for this project
+     * @param compilerOptions     Java compiler options set in pom.xml
      */
     public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
             List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,
-            File testOutputDirectory, List<File> resourceDirs, boolean skipTests, boolean skipUTs, boolean skipITs) {
+            File testOutputDirectory, List<File> resourceDirs, boolean skipTests, boolean skipUTs, boolean skipITs,
+            JavaCompilerOptions compilerOptions) {
         this.buildFile = buildFile;
         this.projectName = projectName;
         this.compileArtifacts = compileArtifacts;
@@ -67,6 +70,7 @@ public class UpstreamProject {
         this.skipITs = skipITs;
 
         // init src/main/java file tracking collections
+        this.compilerOptions = compilerOptions;
         this.recompileJavaSources = new HashSet<File>();
         this.deleteJavaSources = new HashSet<File>();
         this.failedCompilationJavaSources = new HashSet<File>();
@@ -136,5 +140,9 @@ public class UpstreamProject {
 
     public boolean skipITs() {
         return this.skipITs;
+    }
+
+    public JavaCompilerOptions getCompilerOptions() {
+        return this.compilerOptions;
     }
 }


### PR DESCRIPTION
Fix for https://github.com/OpenLiberty/ci.maven/issues/1159
See corresponding ci.maven PR: https://github.com/OpenLiberty/ci.maven/pull/1167

- Dev mode will honour the Maven compiler options set for multi module projects
- Dev mode will watch the pom.xml (single module and multi module projects) for changes to the Maven compiler options. Any changes will take effect on future compilation calls. Marked as a "TODO" is to recompile the entire module when there is a change to the Maven compiler options. 