### PR TITLE
Add recompileDependencies option for dev mode and default behaviour

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2979,7 +2979,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
                     // try recompiling failing project modules that are not dependent on the current
                     // module (upstream of the current module)
-                    if (!project.disableDependencyCompile && recompileDependencies && !initialCompile) {
+                    if (shouldRecompileDependencies(project)) {
                         compileFailingProjects(project, false, executor);
                     }
                     // TODO support hotTests scenario and trigger tests to run on current project
@@ -2995,7 +2995,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         project.failedCompilationJavaSources.addAll(project.recompileJavaSources);
                     }
                     // compile all of the dependent modules (in build order)
-                    if (!project.disableDependencyCompile && recompileDependencies && !initialCompile) {
+                    if (shouldRecompileDependencies(project)) {
                         for (File dependentModule : project.getDependentModules()) {
                             compileModuleForBuildFile(dependentModule, false);
                         }
@@ -3027,7 +3027,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
                         // try recompiling failing project modules that are not dependent on the current
                         // module (upstream of the current module)
-                        if (!project.disableDependencyCompile && recompileDependencies && !initialCompile) {
+                        if (shouldRecompileDependencies(project)) {
                             compileFailingProjects(project, true, executor);
                         }
 
@@ -3041,7 +3041,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                             project.failedCompilationJavaTests.addAll(project.recompileJavaTests);
                         }
                         // compile all of the dependent modules' tests (in build order)
-                        if (!project.disableDependencyCompile && recompileDependencies && !initialCompile) {
+                        if (shouldRecompileDependencies(project)) {
                             for (File dependentModule : project.getDependentModules()) {
                                 compileModuleForBuildFile(dependentModule, true);
                             }
@@ -4590,6 +4590,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             recompileJavaTestSet.addAll(allJavaTestSources);
         }
 
+    }
+
+    // indicates whether to recompile dependencies for the given project module
+    private boolean shouldRecompileDependencies(ProjectModule project) {
+        return (!project.disableDependencyCompile && recompileDependencies && !initialCompile);
     }
 
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3208,30 +3208,12 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         // initial source and test compile of upstream projects
         if (isMultiModuleProject()) {
             for (UpstreamProject project : upstreamProjects) {
-                if (project.getSourceDirectory().exists()) {
-                    Collection<File> allJavaSources = FileUtils
-                            .listFiles(project.getSourceDirectory().getCanonicalFile(), new String[] { "java" }, true);
-                    project.recompileJavaSources.addAll(allJavaSources);
-                }
-                if (project.getTestSourceDirectory().exists()) {
-                    Collection<File> allJavaTestSources = FileUtils.listFiles(
-                            project.getTestSourceDirectory().getCanonicalFile(), new String[] { "java" }, true);
-                    project.recompileJavaTests.addAll(allJavaTestSources);
-                }
+                compileUpstreamModule(project, false);
             }
         }
 
         // initial source and test compile
-        if (this.sourceDirectory.exists()) {
-            Collection<File> allJavaSources = FileUtils.listFiles(this.sourceDirectory.getCanonicalFile(),
-                    new String[] { "java" }, true);
-            recompileJavaSources.addAll(allJavaSources);
-        }
-        if (this.testSourceDirectory.exists()) {
-            Collection<File> allJavaTestSources = FileUtils.listFiles(this.testSourceDirectory.getCanonicalFile(),
-                    new String[] { "java" }, true);
-            recompileJavaTests.addAll(allJavaTestSources);
-        }
+        compileMainModule(false);
     }
 
     private void processFileChanges(
@@ -4428,6 +4410,53 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         }
         buildFiles[count] = buildFile;
         return buildFiles;
+    }
+
+    /**
+     * Compile the entire main module. The main module is the module with the
+     * Liberty configuration.
+     * 
+     * @param testsOnly True if only tests need to be compiled.
+     * @throws IOException
+     */
+    protected void compileMainModule(boolean testsOnly) throws IOException {
+        compileEntireProject(this.sourceDirectory, recompileJavaSources, this.testSourceDirectory, recompileJavaTests,
+                testsOnly);
+    }
+
+    /**
+     * Compile the entire specified module. This is only used in a multi-module
+     * scenario
+     * 
+     * @param project   UpstreamProject, the module to be compiled
+     * @param testsOnly True if only tests need to be compiled
+     * @throws IOException
+     */
+    protected void compileUpstreamModule(UpstreamProject project, boolean testsOnly) throws IOException {
+        compileEntireProject(project.getSourceDirectory(), project.recompileJavaSources,
+                project.getTestSourceDirectory(), project.recompileJavaTests, testsOnly);
+
+    }
+
+    private void compileEntireProject(File sourceDir, Collection<File> recompileJavaSourceSet, File testSourceDir,
+            Collection<File> recompileJavaTestSet, boolean testsOnly) throws IOException {
+
+        // recompile source
+        if (!testsOnly) {
+            if (sourceDir.exists()) {
+                Collection<File> allJavaSources = FileUtils.listFiles(sourceDir.getCanonicalFile(),
+                        new String[] { "java" }, true);
+                recompileJavaSourceSet.addAll(allJavaSources);
+            }
+        }
+
+        // recompile tests
+        if (testSourceDir.exists()) {
+            Collection<File> allJavaTestSources = FileUtils.listFiles(testSourceDir.getCanonicalFile(),
+                    new String[] { "java" }, true);
+            recompileJavaTestSet.addAll(allJavaTestSources);
+        }
+
     }
 
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ProjectModule.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ProjectModule.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
-public class UpstreamProject {
+public class ProjectModule {
 
     private File buildFile;
     private List<String> compileArtifacts;
@@ -35,8 +35,12 @@ public class UpstreamProject {
     public boolean triggerJavaTestRecompile;
     public boolean testSourceDirRegistered;
 
+    // modules that depend on the current module, listed in the build order
+    private List<File> dependentModules;
+    public boolean disableDependencyCompile;
+
     /**
-     * Defines an upstream project for supporting multi-module projects
+     * Defines a project module for supporting multi-module projects
      * 
      * @param buildFile           pom.xml
      * @param projectName         project name (artifactId)
@@ -52,10 +56,10 @@ public class UpstreamProject {
      * @param skipITs             whether to skip integration tests for this project
      * @param compilerOptions     Java compiler options set in pom.xml
      */
-    public UpstreamProject(File buildFile, String projectName, List<String> compileArtifacts,
+    public ProjectModule(File buildFile, String projectName, List<String> compileArtifacts,
             List<String> testArtifacts, File sourceDirectory, File outputDirectory, File testSourceDirectory,
             File testOutputDirectory, List<File> resourceDirs, boolean skipTests, boolean skipUTs, boolean skipITs,
-            JavaCompilerOptions compilerOptions) {
+            JavaCompilerOptions compilerOptions, List<File> dependentModules) {
         this.buildFile = buildFile;
         this.projectName = projectName;
         this.compileArtifacts = compileArtifacts;
@@ -68,6 +72,8 @@ public class UpstreamProject {
         this.skipTests = skipTests;
         this.skipUTs = skipUTs;
         this.skipITs = skipITs;
+        this.dependentModules = dependentModules;
+        this.disableDependencyCompile = false;
 
         // init src/main/java file tracking collections
         this.compilerOptions = compilerOptions;
@@ -148,5 +154,13 @@ public class UpstreamProject {
 
     public void setCompilerOptions(JavaCompilerOptions compilerOptions) {
         this.compilerOptions = compilerOptions;
+    }
+
+    public List<File> getDependentModules() {
+        return this.dependentModules;
+    }
+
+    public void setDependentModules(List<File> dependentModules) {
+        this.dependentModules = dependentModules;
     }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ProjectModule.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ProjectModule.java
@@ -1,3 +1,19 @@
+/**
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.openliberty.tools.common.plugins.util;
 
 import java.io.File;

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -36,7 +36,7 @@ public class BaseDevUtilTest {
         public DevTestUtil(File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null, resourceDirs, hotTests, skipTests, 
-                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null, null);
+                  false, false, null, 30, 30, 5, 500, true, false, false, false, false, null, null, null, 0, false, null, false, null, null, false);
         }
 
         @Override


### PR DESCRIPTION
**Java compilation**
Part of https://github.com/OpenLiberty/ci.maven/issues/1174

Default behaviour for `recompileDependencies` is set in ci.maven/ci.gradle.
When `recompileDependencies=true` recompile all classes in the current and dependent modules when a:
- src/main/java file is added, modified or deleted
- src/test/java files is added, modified or deleted
- build file changes

For multi module projects, when `recompileDependencies=true` always compile in build order: 
1) Failing classes from any upstream modules
2) All classes in the current module
3) All classes in any dependent (downstream) modules

DevUtil uses a `disableDependencyCompile` flag for each project to only compile the current module. This is needed to avoid duplication compilation is step (3) above. 

**multi module hotTests**
Part of https://github.com/OpenLiberty/ci.maven/issues/1175

Run tests on current module and dependent (downstream) modules when:
- a resource directory has been added or deleted
- resource files have been added, modified or deleted
- Java files were deleted without any other changes

To complete the `hotTests` story for multimodules we still need to implement running tests on all dependent modules. 

