### PR TITLE
Add hotTests logic for multi module projects

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3014,7 +3014,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     }
                     // run tests for current project and all dependent projects
                     int numApplicationUpdatedMessages = countApplicationUpdatedMessages();
-                    runTestThread(true, executor, numApplicationUpdatedMessages, skipUTs, false,
+                    runTestThread(true, executor, numApplicationUpdatedMessages, project.skipUTs(), false,
                             getAllBuildFiles(project));
 
                 }


### PR DESCRIPTION
Partial fix for https://github.com/OpenLiberty/ci.maven/issues/1175 (integration tests in ci.maven still need to be added) 

When `hotTests=true` for multi-module projects, always run tests on the modified module and all dependent modules.

Since we have to run tests using the same `ThreadPoolExecutor`, for multi-module projects do not run tests through `recompileJavaSource` or `recompileJavaTest` (that is why [skipRunningTests is true](https://github.com/OpenLiberty/ci.common/pull/275/files#diff-d8b4217f048364ad127bea282a1726d1523aa8359775cee2f4b71eec9cba7140R2979-R2985) when called from `processUpstreamJavaCompilation`). Instead, call `runTestThread()` directly and pass in the current build file and all dependent build files. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>