### PR TITLE
use resolveAsSet

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -490,6 +490,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
             mapBasedInstallKernel.put("single.json.file", jsonRepos);
             mapBasedInstallKernel.put("features.to.resolve", featuresToInstall);
             mapBasedInstallKernel.put("license.accept", acceptLicenseMapValue);
+            mapBasedInstallKernel.put("is.install.server.feature", true);
 
             if (isDebugEnabled()) {
                 mapBasedInstallKernel.put("debug", Level.FINEST);


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/open-liberty/issues/17843

Due to this [PR](https://github.com/OpenLiberty/open-liberty/pull/17319/files#) in installKernelMap, starting 21.0.0.7 plugins started to use `resolve` API instead of `resolveAsSet`. The main difference between the `resolve` and `resolveAsSet` is that resolveAsSet assumes all the resources should start together on one server and detects conflicts.
Changing the plugins behaviour back to using `resolveAsSet` as it only targets 1 server at a time.