### PR TITLE
Compile dependent modules when test dir is added to an upstream module

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -245,6 +245,15 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     public abstract boolean compile(File dir);
 
     /**
+     * Compile the specified directory for the project module
+     * 
+     * @param dir
+     * @param project project module (used in multi-module scenario)
+     * @return
+     */
+    public abstract boolean compile(File dir, ProjectModule project);
+
+    /**
      * Stop the server
      */
     public abstract void stopServer();
@@ -2612,6 +2621,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         compile(this.sourceDirectory);
                         registerAll(srcPath, executor);
                         debug("Registering Java source directory: " + this.sourceDirectory);
+                        // run tests after waiting for app update since app changed
+                        int numApplicationUpdatedMessages = countApplicationUpdatedMessages();
+                        runTestThread(true, executor, numApplicationUpdatedMessages, skipUTs, false, buildFile);
                         sourceDirRegistered = true;
                     } else if (sourceDirRegistered && !this.sourceDirectory.exists()) {
                         cleanTargetDir(outputDirectory);
@@ -2700,12 +2712,21 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         // check if test directory of an upstream project has been added/deleted
                         if (!p.testSourceDirRegistered && p.getTestSourceDirectory().exists()
                                 && p.getTestSourceDirectory().listFiles().length > 0) {
-                            compile(p.getTestSourceDirectory());
+                            compile(p.getTestSourceDirectory(), p);
                             registerAll(p.getTestSourceDirectory().getCanonicalFile().toPath(), executor);
-                            debug("Registering Java test directory: " + p.getTestSourceDirectory());
-                            runTestThread(false, executor, -1, p.skipUTs(), false, getAllBuildFiles(p));
                             p.testSourceDirRegistered = true;
-
+                            debug("Registering Java test directory: " + p.getTestSourceDirectory());
+                            // compile all tests in downstream modules
+                            for (File dependentBuildFile : p.getDependentModules()) {
+                                ProjectModule depModule = getProjectModule(dependentBuildFile);
+                                if (depModule != null) {
+                                    compile(depModule.getTestSourceDirectory(), depModule);
+                                } else {
+                                    // main module
+                                    compile(this.testSourceDirectory);
+                                }
+                            }
+                            runTestThread(false, executor, -1, p.skipUTs(), false, getAllBuildFiles(p));
                         } else if (p.testSourceDirRegistered && !p.getTestSourceDirectory().exists()) {
                             cleanTargetDir(p.getTestOutputDirectory());
                             p.testSourceDirRegistered = false;

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -186,6 +186,12 @@ public class BaseDevUtilTest {
             // not needed for tests
             return true;
         }
+
+        @Override
+        public boolean compile(File dir, ProjectModule project) {
+            // not needed for tests
+            return false;
+        }
         
     }
     


### PR DESCRIPTION
- Call test compile for the corresponding module when a `src/test/java` directory is added to an upstream project (and test compile on all dependent modules) 
- Run tests after a `src/main/java` directory is added for single module projects, or the module with the Liberty configuration for multi-module projects

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>