### PR TITLE
Dev mode, generate features: add generateFeatures parameter 

### DIFF
--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -38,7 +38,7 @@ public class BaseDevUtilTest {
                 List<File> resourceDirs, boolean hotTests, boolean skipTests) {
             super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null,
                     resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true, false, false, false,
-                    false, null, null, null, 0, false, null, false, null, null, false, null, null, null);
+                    false, null, null, null, 0, false, null, false, null, null, false, null, null, null, false);
         }
 
         @Override


### PR DESCRIPTION
Adding the `generateFeatures` parameter in order to move forward with other prototype/development items.
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>