### PR TITLE
Read config document from file and process as server.xml with featureManager element

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDropinXmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDropinXmlDocument.java
@@ -15,22 +15,40 @@
  */
 package io.openliberty.tools.common.plugins.config;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.SAXException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Comment;
 
 public class ServerConfigDropinXmlDocument extends XmlDocument {
-    
+
     private Element featureManager = null;
 
-    private ServerConfigDropinXmlDocument() {    
+    private ServerConfigDropinXmlDocument() {
     }
-    
+
     public static ServerConfigDropinXmlDocument newInstance() throws ParserConfigurationException {
         ServerConfigDropinXmlDocument configDocument = new ServerConfigDropinXmlDocument();
         configDocument.createDocument("server");
+        return configDocument;
+    }
+
+    public static ServerConfigDropinXmlDocument newInstance(File f) throws ParserConfigurationException, SAXException, IOException {
+        if (f == null || !f.exists()) {
+            return null;
+        }
+        ServerConfigDropinXmlDocument configDocument = new ServerConfigDropinXmlDocument();
+        configDocument.createDocument(f);
+        configDocument.featureManager = configDocument.findFeatureManager();
         return configDocument;
     }
 
@@ -38,15 +56,68 @@ public class ServerConfigDropinXmlDocument extends XmlDocument {
         createComment(doc.getDocumentElement(), comment);
     }
 
+    public void createFMComment(String comment) {
+        if (featureManager == null) {
+            return;
+        }
+        if (!hasFMComment(comment)) {
+            // First try to add some blank text to maintain the indentation level.
+            createPaddingText(featureManager);
+            createComment(featureManager, comment);
+        }
+    }
+
+    public void removeFMComment(String comment) {
+        Node commentNode = findFMComment(comment);
+        if (commentNode != null) {
+            Node parent = commentNode.getParentNode();
+            Node sibling = commentNode.getPreviousSibling();
+            if (isWhitespace(sibling)) {
+                parent.removeChild(sibling);
+            }
+            parent.removeChild(commentNode);
+        }
+    }
+
+    private void createPaddingText(Element elem) {
+        // Assuming the model expresses the document
+        // <element>
+        // <text "    "><childE1> etc
+        // First child of <element> is four (or eight or more) blanks. Second child is the actual content.
+        // This can happen when you parse an existing document into the model rather than create it from scratch.
+        Node first = elem.getFirstChild();
+        Node text = null;
+        if (first != null && first instanceof Text) {
+            text = (Text) first.cloneNode(true); // try to copy blanks to maintain indentation level
+        }
+        if (text != null) {
+            insertBeforeBlanks(elem, text); // add blanks between comment and next node: </featureManager>
+        }
+    }
+
     public void createComment(Element elem, String comment) {
         Comment commentElement = doc.createComment(comment);
-        elem.appendChild(commentElement);
+        insertBeforeBlanks(elem, commentElement);
+    }
+
+    private void insertBeforeBlanks(Element elem, Node childElement) {
+        Node lastchild = elem.getLastChild();
+        if (isWhitespace(lastchild)) {
+            // last child is the whitespace preceding the </element> so insert before that
+            elem.insertBefore(childElement, lastchild);
+        } else {
+            elem.appendChild(childElement);
+        }
+    }
+
+    private boolean isWhitespace(Node node) {
+        return node != null && node instanceof Text && ((Text)node).getData().trim().isEmpty();
     }
 
     public void createVariableWithValue(String varName, String varValue, boolean isDefaultValue) {
         createVariableWithValue(doc.getDocumentElement(), varName, varValue, isDefaultValue);
     }
-    
+
     public void createVariableWithValue(Element elem, String varName, String varValue, boolean isDefaultValue) {
         if (varValue == null) {
             return;
@@ -67,5 +138,48 @@ public class ServerConfigDropinXmlDocument extends XmlDocument {
         Node text = doc.createTextNode(name);
         child.appendChild(text);
         featureManager.appendChild(child);
+    }
+
+    public Element findFeatureManager() {
+        Element serverElement = findServerElement();
+        if (serverElement == null) {
+            return null;
+        }
+        Node fmNode = serverElement.getElementsByTagName("featureManager").item(0); // assume just one
+        if (fmNode instanceof Element) {
+            return (Element) fmNode;
+        }
+        return null;
+    }
+
+    public boolean hasFMComment(String comment) {
+        return findFMComment(comment) != null;
+    }
+
+    public Node findFMComment(String comment) {
+        List<Comment> l = findCommentNodes(featureManager);
+        for (Comment c : l) {
+            if (c.getData().contains(comment)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    public List<Comment> findCommentNodes(Element e) {
+        NodeList list = e.getChildNodes();
+        List<Comment> result = new ArrayList<Comment>();
+        for (int i = 0; i < list.getLength(); i++) {
+            if (list.item(i).getNodeType() == Element.COMMENT_NODE) {
+                if (list.item(i) instanceof Comment) {
+                    result.add((Comment)list.item(i));
+                }
+            }
+        }
+        return result;
+    }
+
+    public Element findServerElement() {
+        return doc.getDocumentElement(); // defined for this type of file
     }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
@@ -29,24 +29,38 @@ import org.xml.sax.SAXException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Comment;
 
-public class ServerConfigDropinXmlDocument extends XmlDocument {
+public class ServerConfigXmlDocument extends XmlDocument {
 
     private Element featureManager = null;
 
-    private ServerConfigDropinXmlDocument() {
+    private ServerConfigXmlDocument() {
     }
 
-    public static ServerConfigDropinXmlDocument newInstance() throws ParserConfigurationException {
-        ServerConfigDropinXmlDocument configDocument = new ServerConfigDropinXmlDocument();
+    /**
+     * Create a new Document Object Model for a server configuration file with a single element: server.
+     * @return A reference to the object representing a new DOM
+     * @throws ParserConfigurationException
+     */
+    public static ServerConfigXmlDocument newInstance() throws ParserConfigurationException {
+        ServerConfigXmlDocument configDocument = new ServerConfigXmlDocument();
         configDocument.createDocument("server");
         return configDocument;
     }
 
-    public static ServerConfigDropinXmlDocument newInstance(File f) throws ParserConfigurationException, SAXException, IOException {
+    /**
+     * Create a Document Object Model for a server configuration file and populate it from an existing XML file.
+     * The file should be a valid server configuration file with one top-most element called "server."
+     * @param f  An XML file to read in and store in the created DOM.
+     * @return   A reference to the object representing a new DOM
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     * @throws IOException
+     */
+    public static ServerConfigXmlDocument newInstance(File f) throws ParserConfigurationException, SAXException, IOException {
         if (f == null || !f.exists()) {
             return null;
         }
-        ServerConfigDropinXmlDocument configDocument = new ServerConfigDropinXmlDocument();
+        ServerConfigXmlDocument configDocument = new ServerConfigXmlDocument();
         configDocument.createDocument(f);
         configDocument.featureManager = configDocument.findFeatureManager();
         return configDocument;

--- a/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2018.
+ * (C) Copyright IBM Corporation 2017, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
@@ -48,7 +48,6 @@ public abstract class XmlDocument {
     
     public void createDocument(File xmlFile) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-        //builderFactory.setIgnoringComments(true);
         builderFactory.setCoalescing(true);
         builderFactory.setIgnoringElementContentWhitespace(true);
         builderFactory.setValidating(false);

--- a/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
@@ -48,7 +48,7 @@ public abstract class XmlDocument {
     
     public void createDocument(File xmlFile) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-        builderFactory.setIgnoringComments(true);
+        //builderFactory.setIgnoringComments(true);
         builderFactory.setCoalescing(true);
         builderFactory.setIgnoringElementContentWhitespace(true);
         builderFactory.setValidating(false);

--- a/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
@@ -1,0 +1,128 @@
+package io.openliberty.tools.common.plugins.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument;
+
+public class ServerConfigFileTest {
+
+    public static final String RESOURCES_DIR = "src/test/resources";
+
+    private static final String RESOURCES_SERVER_DIR = RESOURCES_DIR + "/servers";
+
+    private File serversDir = new File(RESOURCES_SERVER_DIR);
+
+    @Test
+    public void testNewInstance() throws Exception {
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        assertTrue(doc.findServerElement().getNodeName().equals("server"));
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 0);
+        assertTrue(doc.findFeatureManager() == null);
+    }
+
+    @Test
+    public void testCreateVars() throws Exception {
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 0);
+        doc.createVariableWithValue("name1", "value1", true);
+        doc.createVariableWithValue("name2", "value2", false);
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 2);
+        assertTrue(doc.findServerElement().getChildNodes().item(0).getNodeType() == Node.ELEMENT_NODE);
+        assertTrue(doc.findServerElement().getChildNodes().item(1).getNodeType() == Node.ELEMENT_NODE);
+    }
+
+    @Test
+    public void testCreateFeatures() throws Exception {
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        doc.createFeature("feature1");
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 1);
+        Node featureMananger = doc.findServerElement().getFirstChild();
+        assertTrue(featureMananger.getChildNodes().getLength() == 1);
+        doc.createFeature("feature2");
+        assertTrue(featureMananger.getChildNodes().getLength() == 2);
+    }
+
+    @Test
+    public void testCreateComment() throws Exception {
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        doc.createComment("Test comment");
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 1);
+        assertTrue(doc.findServerElement().getChildNodes().item(0).getNodeType() == Node.COMMENT_NODE);
+    }
+
+    @Test
+    public void testLMPvars() throws Exception {
+        // Test creating the type of variable file used by LMP.
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        doc.createComment("Test comment");
+        doc.createVariableWithValue("name1", "value1", true);
+        doc.createVariableWithValue("name2", "value2", false);
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 3);
+    }
+
+    @Test
+    public void testNewFileInstance() throws Exception {
+        File serverXml = new File(serversDir, "server.xml");
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
+        assertTrue(doc.findServerElement().getNodeName().equals("server"));
+        assertTrue(doc.findServerElement().getChildNodes().getLength() > 0);
+    }
+
+    @Test
+    public void testAddFMComment() throws Exception {
+        File serverXml = new File(serversDir, "server.xml");
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
+        assertTrue(doc.findFeatureManager() != null);
+        doc.createFMComment("test comment");
+        assertTrue(doc.hasFMComment("test comment"));
+        Node comment = doc.findFMComment("test comment");
+        assertTrue(comment.getNodeType() == Node.COMMENT_NODE);
+    }
+
+    @Test
+    public void testInvalidAddFMComment() throws Exception {
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
+        assertTrue(doc.findFeatureManager() == null);
+        doc.createFMComment("test comment");
+        assertTrue(doc.findServerElement().getChildNodes().getLength() == 0);
+    }
+
+    @Test
+    public void testRemoveFMComment() throws Exception {
+        File serverXml = new File(serversDir, "server.xml");
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
+        assertTrue(doc.findFeatureManager() != null);
+        doc.createFMComment("test comment");
+        assertTrue(doc.hasFMComment("test comment"));
+        doc.removeFMComment("test comment");
+        assertFalse(doc.hasFMComment("test comment"));
+    }
+
+    @Test
+    public void testSpacing() throws Exception {
+        File serverXml = new File(serversDir, "server.xml");
+        ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
+        Node featureManager = doc.findFeatureManager();
+        int indent = -1;
+        Node text = featureManager.getFirstChild(); // expecting children text("\n        "), element(feature), text("\n    ")
+        if (text.getNodeType() == Node.TEXT_NODE) {
+            indent = text.getTextContent().length();
+        }
+        assertTrue(indent == 9);
+        doc.createFMComment("test comment");
+        Node comment = doc.findFMComment("test comment");
+        Node spacing = comment.getPreviousSibling();
+        assertTrue(spacing.getNodeType() == Node.TEXT_NODE);
+        assertTrue(spacing.getTextContent().length() == indent); // comment indented to same level as features
+        Node closingSpace = comment.getNextSibling();
+        assertTrue(closingSpace.getNodeType() == Node.TEXT_NODE);
+        assertTrue(closingSpace.getTextContent().length() < indent); // </featureManager> indented less than features
+    }
+}

--- a/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
@@ -1,7 +1,21 @@
+/**
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openliberty.tools.common.plugins.util;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;


### PR DESCRIPTION
This code is in ServerConfigDropinXmlDocument which is not a great name for the purpose to which it is now being put. This class is now used also to handle server.xml files where previously it just created the variable xml files and the generated features xml files.

We could create a new class with a name such as ServerConfigXmlDocument which extends ServerConfigDropinXmlDocument if we want to separate the server.xml handling. I'm not thrilled with that hierarchy so we could create a new common sub-class both these classes could extend.

Let me know what you think.

Also, do you know why XmlDocument wants to ignore comments?