### PR TITLE
Run container server commands from PATH

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1547,7 +1547,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         // Options must precede this in any order. Image name and command code follows.
         command.append(" " + imageName);
         // Command to start the server
-        command.append(" /opt/ol/wlp/bin/server" + ((libertyDebug) ? " debug " : " run ")  + "defaultServer");
+        command.append(" server" + ((libertyDebug) ? " debug " : " run ")  + "defaultServer");
         // All the Liberty variable definitions must appear after the -- option.
         // Important: other Liberty options must appear before --
         command.append(" -- --"+DEVMODE_PROJECT_ROOT+"="+DEVMODE_DIR_NAME);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -906,7 +906,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
             featureList.append(feature).append(" ");
         }
 
-        String featureUtilityCommand = "docker exec -e FEATURE_LOCAL_REPO=/devmode-maven-cache " + containerName + " /liberty/bin/featureUtility installFeature " + featureList;
+        String featureUtilityCommand = "docker exec -e FEATURE_LOCAL_REPO=/devmode-maven-cache " + containerName + " featureUtility installFeature " + featureList;
         if (acceptLicense) {
             featureUtilityCommand += "--acceptLicense";
         }


### PR DESCRIPTION
For `devc`, run server commands without the absolute path, since the Liberty bin directory is in $PATH for both Open Liberty and WebSphere Liberty container images.

Fixes https://github.com/OpenLiberty/ci.maven/issues/1246