### PR TITLE
Use build dir for temp Dockerfile, cleanup imports

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1158,7 +1158,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         File tempDockerfile = null;
         try {
             debug("Creating temp Dockerfile...");
-            tempDockerfile = File.createTempFile("tempDockerfile", "");
+            File devcHiddenFolder = new File(buildDirectory, DEVC_HIDDEN_FOLDER);
+            devcHiddenFolder.mkdirs();
+            tempDockerfile = File.createTempFile("tempDockerfile", "", devcHiddenFolder);
             debug("temp Dockerfile: " + tempDockerfile);
             tempDockerfilePath = tempDockerfile.toPath(); // save name to clean up later
             if (keepTempDockerfile) {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -35,8 +35,8 @@ public class BaseDevUtilTest {
     public class DevTestUtil extends DevUtil {
 
         public DevTestUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory,
-                List<File> resourceDirs, boolean hotTests, boolean skipTests) {
-            super(null, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null,
+                List<File> resourceDirs, boolean hotTests, boolean skipTests) throws IOException {
+            super(temp.newFolder(), serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, null, null,
                     resourceDirs, hotTests, skipTests, false, false, null, 30, 30, 5, 500, true, false, false, false,
                     false, null, null, null, 0, false, null, false, null, null, false, null, null, null);
         }
@@ -202,7 +202,7 @@ public class BaseDevUtilTest {
         
     }
     
-    public DevUtil getNewDevUtil(File serverDirectory)  {
+    public DevUtil getNewDevUtil(File serverDirectory) throws IOException  {
         return new DevTestUtil(serverDirectory, null, null, null, null, false, false);
     }
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
@@ -26,9 +26,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
-import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
-import io.openliberty.tools.common.plugins.util.PluginExecutionException;
-import io.openliberty.tools.common.plugins.util.PluginScenarioException;
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil.ProductProperties;
 
 public class BaseInstallFeatureUtilTest {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
@@ -16,20 +16,12 @@
 package io.openliberty.tools.common.plugins.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-
-import io.openliberty.tools.common.plugins.util.DevUtil;
-import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 
 public class DevUtilHostnamePortTest extends BaseDevUtilTest {
 
@@ -59,7 +51,7 @@ public class DevUtilHostnamePortTest extends BaseDevUtilTest {
         assertEquals(null, util.getHttpPort());
     }
 
-    private void testHostnameAndHttpPort(String message) throws PluginExecutionException {
+    private void testHostnameAndHttpPort(String message) throws PluginExecutionException, IOException {
         DevUtil util = getNewDevUtil(null);
         int portPrefixIndex = util.parseHostName(message);
         util.parseHttpPort(message, portPrefixIndex);
@@ -86,7 +78,7 @@ public class DevUtilHostnamePortTest extends BaseDevUtilTest {
     };
 
     @Test
-    public void testParseHttpsPort() throws PluginExecutionException {
+    public void testParseHttpsPort() throws PluginExecutionException, IOException {
         for (String message : tcpChannelTranslations) {
             String injectedHttp = message.replace("{0}", "defaultHttpEndpoint").replace("{1}", "localhost  (IPv4: 127.0.0.1)").replace("{2}", "9080");
             String injectedHttps = message.replace("{0}", "defaultHttpEndpoint-ssl").replace("{1}", "localhost  (IPv4: 127.0.0.1)").replace("{2}", "9443");

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilRunTestThreadTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -34,7 +35,7 @@ public class DevUtilRunTestThreadTest extends BaseDevUtilTest {
     private class RunTestThreadUtil extends DevTestUtil {
         public int counter = 0;
 
-        public RunTestThreadUtil(boolean hotTests) {
+        public RunTestThreadUtil(boolean hotTests) throws IOException {
             super(null, null, null, null, null, hotTests, false);
         }
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -15,11 +15,11 @@
  */
 package io.openliberty.tools.common.plugins.util;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -38,8 +38,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import io.openliberty.tools.common.plugins.util.DevUtil;
 
 public class DevUtilTest extends BaseDevUtilTest {
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetInstallMapTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetInstallMapTest.java
@@ -30,8 +30,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
-
 @RunWith(Parameterized.class)
 public class InstallFeatureUtilGetInstallMapTest {
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -33,8 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
-
 public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureUtilTest {
     private static File serverDirectory = null;
     private static File src = null;

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
@@ -16,9 +16,9 @@
 package io.openliberty.tools.common.plugins.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,9 +28,6 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
-import io.openliberty.tools.common.plugins.util.PluginExecutionException;
-import io.openliberty.tools.common.plugins.util.PluginScenarioException;
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil.ProductProperties;
 
 public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {


### PR DESCRIPTION
- Use `target/.libertyDevc` or `build/.libertyDevc` for temp Dockerfile location instead of $TEMP, so that paths can be relativized
- Cleanup imports in tests

Fixes https://github.com/OpenLiberty/ci.maven/issues/1044