### PR TITLE
Improve error message for feature conflicts

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3344,7 +3344,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 }
             }
             // after compiling Java scan for Liberty features.
-            if (builtJava && generateFeatures) {
+            if (builtJava && generateFeatures && !initialCompile) {
                 libertyGenerateFeatures();
             }
 


### PR DESCRIPTION
- Improve the error message when there is a feature conflict from install-feature
- Do not generate features again on dev mode's initial compile

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>