### PR TITLE
Add dev mode help hotkey, rearrange messages, refactor hot key code

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2260,22 +2260,13 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         }
 
         if (!inputUnavailable) {
-            // the following will be printed on startup and every time after the tests run
-            if (blockTests) {
-                printMavenClasspathErrMsg(true);
-            } else {
-                if (hotTests) {
-                    String message = "Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.";
-                    info(startup ? formatAttentionMessage(message) : message);
-                } else {
-                    String message = "To run tests on demand, press Enter.";
-                    info(startup ? formatAttentionMessage(message) : message);
-                }
-            }
-
-            // the following will be printed only on startup or restart
             if (startup) {
-                printHotkeyMessages();
+                // the following will be printed only on startup or restart
+                info(formatAttentionMessage("To see the help menu for available actions, type 'h' and press Enter."));
+                info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+            } else {
+                // the following will be printed every time after the tests run
+                printTestsMessage(false);
             }
         } else {
             debug("Cannot read user input, setting hotTests to true.");
@@ -2359,13 +2350,29 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         }
     }
 
-    private void printHotkeyMessages() {
+    private void printTestsMessage(boolean formatForAttention) {
+        if (blockTests) {
+            printMavenClasspathErrMsg(true);
+        } else {
+            if (hotTests) {
+                String message = "Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.";
+                info(formatForAttention ? formatAttentionMessage(message) : message);
+            } else {
+                String message = "To run tests on demand, press Enter.";
+                info(formatForAttention ? formatAttentionMessage(message) : message);
+            }
+        }
+    }
+
+    private void printHelpMessages() {
+        printTestsMessage(true);
+
         if (container) {
             info(formatAttentionMessage("To rebuild the Docker image and restart the container, type 'r' and press Enter."));
         } else {
             info(formatAttentionMessage("To restart the server, type 'r' and press Enter."));
         }
-        info(formatAttentionMessage("To see the help menu, type 'h' and press Enter."));
+        info(formatAttentionMessage("To see the help menu for available actions, type 'h' and press Enter."));
         info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
     }
 
@@ -2440,7 +2447,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         }
                     } else if (h.isPressed(line)) {
                         info(formatAttentionBarrier());
-                        printHotkeyMessages();
+                        printHelpMessages();
                         info(formatAttentionBarrier());
                     } else {
                         if (blockTests) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/HotKey.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/HotKey.java
@@ -1,3 +1,19 @@
+/**
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.openliberty.tools.common.plugins.util;
 
 public class HotKey {
@@ -5,7 +21,7 @@ public class HotKey {
     private String[] keywords; 
 
     /**
-     * @param keywords The words that triggers the hotkey. Can single letters or full words.
+     * @param keywords The words that can trigger the hotkey. Can be single letters or full words.
      */
     public HotKey(String... keywords){
         this.keywords = keywords;


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1269

See updated dev mode startup messages, and then pressing h:
<img width="707" alt="Screen Shot 2021-10-28 at 5 26 21 PM" src="https://user-images.githubusercontent.com/29640130/139443179-ac34a197-751b-4249-8a1a-92cfdb5e7da4.png">

With devc:
<img width="727" alt="Screen Shot 2021-10-28 at 6 35 53 PM" src="https://user-images.githubusercontent.com/29640130/139443416-2bf770b4-3499-4487-9670-e2911c0b5e4d.png">

With hotTests:
<img width="957" alt="Screen Shot 2021-10-28 at 6 38 06 PM" src="https://user-images.githubusercontent.com/29640130/139443458-99dd7d45-ba21-4fb8-b835-e9042c08186b.png">

With Maven 3.8.3 with classpath issue:
<img width="1113" alt="Screen Shot 2021-10-28 at 6 39 33 PM" src="https://user-images.githubusercontent.com/29640130/139443498-cfe6bdb5-4ec9-44c3-8e9d-1bea249b4372.png">


