### PR TITLE
Add g and o hotkeys, show feature gen flag status

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2368,6 +2368,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     private void printHelpMessages() {
         printFeatureGenerationStatus();
+        printFeatureGenerationHotkeys();
         printTestsMessage(true);
         if (container) {
             info(formatAttentionMessage("To rebuild the Docker image and restart the container, type 'r' and press Enter."));
@@ -2379,7 +2380,15 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     private void printFeatureGenerationStatus() {
-        info(formatAttentionMessage("Automatic generation of server features: [ " + (generateFeatures ? "On" : "Off") + " ]"));
+        info(formatAttentionMessage("Automatic generation of server features: " + getFormattedBooleanString(generateFeatures)));
+    }
+
+    private void printFeatureGenerationHotkeys() {
+        info(formatAttentionMessage("To toggle the automatic generation of features, type 'g' and press Enter."));
+        if (generateFeatures) {
+            // If generateFeatures is enabled, then also describe the optimize hotkey
+            info(formatAttentionMessage("To optimize the list of generated features, type 'o' and press Enter."));
+        }
     }
 
     private String formatAttentionBarrier() {
@@ -2392,6 +2401,27 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     private String formatAttentionMessage(String message) {
         return "*        " + message;
+    }
+
+    private String getFormattedBooleanString(boolean bool) {
+        return "[ " + (bool ? "On" : "Off") + " ]";
+    }
+
+    private void toggleFeatureGeneration() {
+        generateFeatures = !generateFeatures;
+        info("Setting automatic generation of features to: " + getFormattedBooleanString(generateFeatures));
+        if (generateFeatures) {
+            // If hotkey is toggled to “true”, generate features right away.
+            generateFeaturesWithAllClasses();
+        }
+    }
+
+    /**
+     * Pass user specified features plus all classes to generateFeatures goal.
+     */
+    private void generateFeaturesWithAllClasses() {
+        info("Generating optimized features list...");
+        // TODO
     }
 
     private class HotkeyReader implements Runnable {
@@ -2429,6 +2459,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             HotKey q = new HotKey("q", "quit", "exit");
             HotKey h = new HotKey("h", "help");
             HotKey r = new HotKey("r");
+            HotKey g = new HotKey("g");
+            HotKey o = new HotKey("o");
             if (scanner.hasNextLine()) {
                 synchronized (inputUnavailable) {
                     inputUnavailable.notify();
@@ -2455,6 +2487,15 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         info(formatAttentionBarrier());
                         printHelpMessages();
                         info(formatAttentionBarrier());
+                    } else if (g.isPressed(line)) {
+                        toggleFeatureGeneration();
+                    } else if (o.isPressed(line)) {
+                        if (generateFeatures) {
+                            generateFeaturesWithAllClasses();
+                        } else {
+                            warn("Cannot optimize features because automatic generation of features is off.");
+                            warn("To toggle the automatic generation of features, type 'g' and press Enter.");
+                        }
                     } else {
                         if (blockTests) {
                             printMavenClasspathErrMsg(false);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2257,6 +2257,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             info(formatAttentionBarrier());
 
             info(formatAttentionTitle("Liberty is running in dev mode."));
+
+            printFeatureGenerationStatus();
         }
 
         if (!inputUnavailable) {
@@ -2365,8 +2367,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     private void printHelpMessages() {
+        printFeatureGenerationStatus();
         printTestsMessage(true);
-
         if (container) {
             info(formatAttentionMessage("To rebuild the Docker image and restart the container, type 'r' and press Enter."));
         } else {
@@ -2374,6 +2376,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         }
         info(formatAttentionMessage("To see the help menu for available actions, type 'h' and press Enter."));
         info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+    }
+
+    private void printFeatureGenerationStatus() {
+        info(formatAttentionMessage("Automatic generation of server features: [ " + (generateFeatures ? "On" : "Off") + " ]"));
     }
 
     private String formatAttentionBarrier() {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1269
Fixes https://github.com/OpenLiberty/ci.maven/issues/1266

Screenshot showing the following sequence:
1. Dev mode startup with flag status (feature gen on)
2. h (feature gen is on) - notice g and o are in the help menu
3. o to optimize
4. g (turn feature gen off)
5. h (feature gen is off) - notice o is not in the help menu
6. o - gets warning that feature gen is off
7. g (turn feature gen on) - also triggers optimize
<img width="681" alt="Screen Shot 2021-10-29 at 11 41 32 AM" src="https://user-images.githubusercontent.com/29640130/139463952-0726e96c-b725-4060-b1cf-b59bbd13446e.png">


