### PR TITLE
Omit previously generated features when optimizing features

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2420,16 +2420,21 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         info("Setting automatic generation of features to: " + getFormattedBooleanString(generateFeatures));
         if (generateFeatures) {
             // If hotkey is toggled to “true”, generate features right away.
-            generateFeaturesWithAllClasses();
+            optimizeFeatures();
         }
     }
 
     /**
-     * Pass user specified features plus all classes to generateFeatures goal.
+     * Generate features using all classes and only user specified features.
      */
-    private void generateFeaturesWithAllClasses() {
+    private void optimizeFeatures() {
         info("Generating optimized features list...");
-        // TODO
+        // TODO make this not include previously generated features
+        try {
+            libertyGenerateFeatures();
+        } catch (PluginExecutionException e) {
+            error("An error occurred while trying to optimize features: " + e.getMessage(), e);
+        }
     }
 
     private class HotkeyReader implements Runnable {
@@ -2499,7 +2504,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         toggleFeatureGeneration();
                     } else if (o.isPressed(line)) {
                         if (generateFeatures) {
-                            generateFeaturesWithAllClasses();
+                            optimizeFeatures();
                         } else {
                             warn("Cannot optimize features because automatic generation of features is off.");
                             warn("To toggle the automatic generation of features, type 'g' and press Enter.");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2429,7 +2429,6 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      */
     private void optimizeFeatures() {
         info("Generating optimized features list...");
-        // TODO make this not include previously generated features
         try {
             libertyGenerateFeatures();
         } catch (PluginExecutionException e) {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -66,6 +66,12 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         Set<String> getServerResult = util.getServerFeatures(serverDirectory, null);
         assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult);
     }
+
+        
+    private void verifyServerFeatures(Set<String> expected, Set<String> ignoreFiles) throws Exception {
+        Set<String> getServerResult = util.getServerFeatures(serverDirectory, null, ignoreFiles);
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult);
+    }
     
     private void verifyServerFeaturesPreserveCase(Set<String> expected) throws Exception {
         util.setLowerCaseFeatures(false);
@@ -170,6 +176,37 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("overrides");
 
         verifyServerFeatures(expected);
+    }
+
+    /**
+     * Tests server.xml with config dropins overrides, ignoring a specific file
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConfigOverridesIgnoreFile() throws Exception{
+        copy("server.xml");
+        copyAsName("generated-features.xml", "configDropins/overrides/generated-features.xml");
+
+        Set<String> expected = new HashSet<String>();
+        expected.add("orig");
+        expected.add("generated");
+
+        verifyServerFeatures(expected); // without ignore
+
+        Set<String> ignoreSet1 = new HashSet<String>();
+        ignoreSet1.add("some-other-ignored-features.xml");
+
+        verifyServerFeatures(expected, ignoreSet1); // ignoring some unrelated file
+
+        Set<String> ignoreSet2 = new HashSet<String>();
+        ignoreSet2.add("generated-features.xml");
+
+        Set<String> expected2 = new HashSet<String>();
+        expected2.add("orig");
+
+        verifyServerFeatures(expected2, ignoreSet2); // ignore specified file
+
     }
 
     /**

--- a/src/test/resources/servers/generated-features.xml
+++ b/src/test/resources/servers/generated-features.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+	<featureManager>
+        <feature>generated</feature>
+    </featureManager>
+</server>


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1294

- Call generateFeatures when optimizing features in dev mode
- Omit previously generated features when optimizing features
- Add unit test for getting list of features without specific dropins files

Note: This gets the correct optimized result from binary scanner but does not yet properly write the optimized features to the generated file.