### PR TITLE
Do not watch files that are in the source directory and the loose app config file

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
@@ -28,7 +28,6 @@ public class LooseConfigData extends XmlDocument {
 
     private String projectRoot = null;
     private String sourceOnDiskName = null;
-    private File xmlDoc = null;
 
     /**
      * Set both projectRoot and sourceOnDiskName to control the name used when an element is added.
@@ -111,11 +110,6 @@ public class LooseConfigData extends XmlDocument {
     
     public void toXmlFile(File xmlFile) throws Exception {        
         writeXMLDocument(xmlFile);
-        this.xmlDoc = xmlFile;
-    }
-
-    public File getXmlFile() {
-        return this.xmlDoc;
     }
     
     public Element getDocumentRoot() {
@@ -136,10 +130,4 @@ public class LooseConfigData extends XmlDocument {
         child.setAttribute("targetInArchive", target);
         parent.appendChild(child);
     }
-
-    // public void getSourceOnDiskElement() {
-    //     if (sourceOnDiskName != null) {
-
-    //     }
-    // }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/LooseConfigData.java
@@ -28,6 +28,7 @@ public class LooseConfigData extends XmlDocument {
 
     private String projectRoot = null;
     private String sourceOnDiskName = null;
+    private File xmlDoc = null;
 
     /**
      * Set both projectRoot and sourceOnDiskName to control the name used when an element is added.
@@ -110,6 +111,11 @@ public class LooseConfigData extends XmlDocument {
     
     public void toXmlFile(File xmlFile) throws Exception {        
         writeXMLDocument(xmlFile);
+        this.xmlDoc = xmlFile;
+    }
+
+    public File getXmlFile() {
+        return this.xmlDoc;
     }
     
     public Element getDocumentRoot() {
@@ -130,4 +136,10 @@ public class LooseConfigData extends XmlDocument {
         child.setAttribute("targetInArchive", target);
         parent.appendChild(child);
     }
+
+    // public void getSourceOnDiskElement() {
+    //     if (sourceOnDiskName != null) {
+
+    //     }
+    // }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2564,7 +2564,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     if (shouldIncludeSources(p.getPackagingType())) {
                         // watch src/main/java dir
                         if (p.getSourceDirectory().exists()) {
-                            omitWatchingFiles.addAll(getOmitFilesList(looseAppFile, p.getSourceDirectory().getCanonicalFile().toPath()));
+                            omitWatchingFiles.addAll(getOmitFilesList(looseAppFile, p.getSourceDirectory().getCanonicalPath()));
                             registerAll(p.getSourceDirectory().getCanonicalFile().toPath(), executor);
                             p.sourceDirRegistered = true;
                         }
@@ -2596,7 +2596,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
             if (shouldIncludeSources(packagingType)) {
                 if (this.sourceDirectory.exists()) {
-                    omitWatchingFiles.addAll(getOmitFilesList(looseAppFile, srcPath));
+                    omitWatchingFiles.addAll(getOmitFilesList(looseAppFile, this.sourceDirectory.getCanonicalPath()));
                     registerAll(srcPath, executor);
                     sourceDirRegistered = true;
                 }
@@ -3075,11 +3075,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * directory and should be omitted from watching.
      * 
      * @param looseAppFile Loose Application configuration file
-     * @param srcDirectory the source directory path
+     * @param srcDirectoryPath the source directory path
      * @return a list of files that should be omitted from watching as they are on
      *         the source directory path and exist in the loose app config file
      */
-    protected Collection<File> getOmitFilesList(File looseAppFile, Path srcDirectory) {
+    protected Collection<File> getOmitFilesList(File looseAppFile, String srcDirectoryPath) {
         Collection<File> omitFiles = new ArrayList<File>();
         try {
             if (looseAppFile != null && looseAppFile.exists()) {
@@ -3094,10 +3094,12 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         if (node.getNodeName().equals("dir") || node.getNodeName().equals("file")) {
                             String srcOnDiskNodeText = node.getAttributes().getNamedItem("sourceOnDisk").getTextContent();
                             if (container) {
-                                srcOnDiskNodeText = srcOnDiskNodeText.replace("${"+DEVMODE_PROJECT_ROOT+"}", getLooseAppProjectRoot(projectDirectory, multiModuleProjectDirectory).getCanonicalPath());
+                                srcOnDiskNodeText = srcOnDiskNodeText.replace("${" + DEVMODE_PROJECT_ROOT + "}",
+                                        getLooseAppProjectRoot(projectDirectory, multiModuleProjectDirectory)
+                                                .getCanonicalPath());
                             }
                             File srcOnDiskFile = new File(srcOnDiskNodeText);
-                            if (srcOnDiskFile.getCanonicalPath().startsWith(srcDirectory.toString())) {
+                            if (srcOnDiskFile.getCanonicalPath().startsWith(srcDirectoryPath)) {
                                 omitFiles.add(srcOnDiskFile);
                             }
                         }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -300,6 +300,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      */
     public abstract boolean isLooseApplication();
 
+    public abstract File getLooseApplicationFile();
+
     /**
      * Is the classpath properly resolved. Only relevent for Maven projects.
      * Returns false if Maven thread classpath error is detected.
@@ -2500,6 +2502,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         this.dockerfileUsed = null;
         this.initialCompile = true;
         this.disableDependencyCompile = false;
+        getLooseApplicationFile(); // TODO do not register directories that are in srcDir and loose app file
 
         try {
             watcher = FileSystems.getDefault().newWatchService();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3107,7 +3107,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 }
             }
         } catch (ParserConfigurationException | SAXException | IOException e) {
-            debug("Unable to read loose application configuration file: " + looseAppFile.toString());
+            error("Unable to read loose application configuration file: " + looseAppFile.toString());
             return null;
         }
         return omitFiles;
@@ -4244,7 +4244,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                             }
                         }
                         for (File omitFile : omitWatchingFiles) {
-                            if (dir.startsWith(omitFile.getCanonicalPath())) {
+                            if (dir.startsWith(omitFile.getCanonicalPath() + File.separator)) {
                                 debug("Skipping subdirectory " + dir.toString() + " since it is in the omit files list");
                                 return FileVisitResult.CONTINUE;
                             }
@@ -5065,7 +5065,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         try {
             if (isMultiModuleProject()) {
                 for (ProjectModule p : upstreamProjects) {
-                    if (p.getSourceDirectory().getCanonicalPath().startsWith(dirAdded.getCanonicalPath())) {
+                    if (p.getSourceDirectory().getCanonicalPath().startsWith(dirAdded.getCanonicalPath() + File.separator)) {
                         return true;
                     }
                 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -307,6 +307,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      */
     public abstract boolean isLooseApplication();
 
+    /**
+     * Get the loose application configuration file.
+     * @return File loose application configuration file
+     */
     public abstract File getLooseApplicationFile();
 
     /**

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -195,6 +195,12 @@ public class BaseDevUtilTest {
         }
 
         @Override
+        public File getLooseApplicationFile() {
+            // not needed for tests
+            return null;
+        }
+
+        @Override
         public boolean compile(File dir, ProjectModule project) {
             // not needed for tests
             return false;

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -32,11 +32,16 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class DevUtilTest extends BaseDevUtilTest {
@@ -46,6 +51,12 @@ public class DevUtilTest extends BaseDevUtilTest {
     File srcDir;
     File targetDir;
     DevUtil util;
+    private static File src;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        src = new File("src/test/resources/servers");
+    }
 
     @Before
     public void setUp() throws IOException {
@@ -502,5 +513,21 @@ public class DevUtilTest extends BaseDevUtilTest {
 
         assertEquals("Parent should be the drive root", new File("/"), DevUtil.getLongestCommonDir(new File("/a/b/c"), new File("/d/e/f")));
     }
+
+    private File copyToServerAppsDir(String origName) throws IOException {
+        File file = new File(src, origName);
+        File destFile = new File(serverDirectory, "apps/" + origName);
+        FileUtils.copyFile(file, destFile);
+        return destFile;
+    }
+
+    @Test
+    public void testOmitFilesList() throws Exception {
+        File looseAppFile = copyToServerAppsDir("looseApp.xml");
+        Collection<File> omitFiles = new ArrayList<File>();
+        omitFiles.add(new File("/src/main/webapp"));
+        assertEquals(omitFiles, util.getOmitFilesList(looseAppFile, new File("/src/main/webapp").getCanonicalPath()));
+    }
+
 
 }

--- a/src/test/resources/servers/looseApp.xml
+++ b/src/test/resources/servers/looseApp.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive>
+    <dir sourceOnDisk="/src/main/webapp" targetInArchive="/"/>
+    <file sourceOnDisk="target/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+</archive>


### PR DESCRIPTION
Adds logic to not watch files that are in the source directory and specified in the loose application file.
Part of https://github.com/OpenLiberty/ci.maven/issues/1285