### PR TITLE
Write XML document without indentation if the document has indentation embedded in it.

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
@@ -70,15 +70,18 @@ public class ServerConfigXmlDocument extends XmlDocument {
         createComment(doc.getDocumentElement(), comment);
     }
 
-    public void createFMComment(String comment) {
+    // Return true if the document was changed and false otherwise.
+    public boolean createFMComment(String comment) {
         if (featureManager == null) {
-            return;
+            return false;
         }
         if (!hasFMComment(comment)) {
             // First try to add some blank text to maintain the indentation level.
             createPaddingText(featureManager);
             createComment(featureManager, comment);
+            return true;
         }
+        return false;
     }
 
     public void removeFMComment(String comment) {
@@ -100,9 +103,10 @@ public class ServerConfigXmlDocument extends XmlDocument {
         // First child of <element> is four (or eight or more) blanks. Second child is the actual content.
         // This can happen when you parse an existing document into the model rather than create it from scratch.
         Node first = elem.getFirstChild();
+
         Node text = null;
         if (first != null && first instanceof Text) {
-            text = (Text) first.cloneNode(true); // try to copy blanks to maintain indentation level
+            text = first.cloneNode(true); // try to copy blanks to maintain indentation level
         }
         if (text != null) {
             insertBeforeBlanks(elem, text); // add blanks between comment and next node: </featureManager>
@@ -122,10 +126,6 @@ public class ServerConfigXmlDocument extends XmlDocument {
         } else {
             elem.appendChild(childElement);
         }
-    }
-
-    private boolean isWhitespace(Node node) {
-        return node != null && node instanceof Text && ((Text)node).getData().trim().isEmpty();
     }
 
     public void createVariableWithValue(String varName, String varValue, boolean isDefaultValue) {

--- a/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/XmlDocument.java
@@ -31,6 +31,8 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
 public abstract class XmlDocument {
@@ -54,7 +56,7 @@ public abstract class XmlDocument {
         DocumentBuilder builder = builderFactory.newDocumentBuilder();
         doc = builder.parse(xmlFile);
     }
-        
+
     public void writeXMLDocument(String fileName) throws IOException, TransformerException {
         File f = new File(fileName);
         writeXMLDocument(f);
@@ -75,10 +77,24 @@ public abstract class XmlDocument {
         transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
         transformer.setOutputProperty(OutputKeys.VERSION, "1.0");
         transformer.setOutputProperty(OutputKeys.ENCODING,"UTF-8");
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        if (isIndented()) {
+            transformer.setOutputProperty(OutputKeys.INDENT, "no");
+        } else {
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        }
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
         
         transformer.transform(source, result);
         outFile.close();
+    }
+
+    protected boolean isIndented() {
+        // if the first child is just white space then the document contains indentation information
+        Node x = doc.getDocumentElement().getFirstChild();
+        return isWhitespace(x);
+    }
+
+    protected boolean isWhitespace(Node node) {
+        return node != null && node instanceof Text && ((Text)node).getData().trim().isEmpty();
     }
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigFileTest.java
@@ -94,7 +94,7 @@ public class ServerConfigFileTest {
         File serverXml = new File(serversDir, "server.xml");
         ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
         assertTrue(doc.findFeatureManager() != null);
-        doc.createFMComment("test comment");
+        assertTrue(doc.createFMComment("test comment"));
         assertTrue(doc.hasFMComment("test comment"));
         Node comment = doc.findFMComment("test comment");
         assertTrue(comment.getNodeType() == Node.COMMENT_NODE);
@@ -104,7 +104,7 @@ public class ServerConfigFileTest {
     public void testInvalidAddFMComment() throws Exception {
         ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance();
         assertTrue(doc.findFeatureManager() == null);
-        doc.createFMComment("test comment");
+        assertFalse(doc.createFMComment("test comment"));
         assertTrue(doc.findServerElement().getChildNodes().getLength() == 0);
     }
 
@@ -113,7 +113,7 @@ public class ServerConfigFileTest {
         File serverXml = new File(serversDir, "server.xml");
         ServerConfigXmlDocument doc = ServerConfigXmlDocument.newInstance(serverXml);
         assertTrue(doc.findFeatureManager() != null);
-        doc.createFMComment("test comment");
+        assertTrue(doc.createFMComment("test comment"));
         assertTrue(doc.hasFMComment("test comment"));
         doc.removeFMComment("test comment");
         assertFalse(doc.hasFMComment("test comment"));
@@ -130,7 +130,7 @@ public class ServerConfigFileTest {
             indent = text.getTextContent().length();
         }
         assertTrue(indent == 9);
-        doc.createFMComment("test comment");
+        assertTrue(doc.createFMComment("test comment"));
         Node comment = doc.findFMComment("test comment");
         Node spacing = comment.getPreviousSibling();
         assertTrue(spacing.getNodeType() == Node.TEXT_NODE);


### PR DESCRIPTION
Also return true if adding a comment to XML document is successful. Update test.

The document will have indentation embedded in the case it is read from a file by the parser. The embedded spaces appear as Text nodes which contain, for example, \n<blank><blank><blank><blank>. The code currently checks for these spaces. 

Another design would be to overload the setXmlStandalone() flag which is set when the document is created internally and is currently not set by the parser when the document is read from a file. We could control the indentation using that flag. 

Alternatively do the reviewers know of other W3C Document (org.w3c.dom.Document) properties which could indicate embedded indentation whitespace?

Fixes https://github.com/OpenLiberty/ci.maven/issues/1301