### PR TITLE
Remove extra generate features from gradle initial compile

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3495,12 +3495,6 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 }
             }
 
-            if (builtJava && initialCompile && generateFeatures && gradle) {
-                // check for initial Gradle compile and scan for Liberty features across entire
-                // project as class files may have not been modified
-                libertyGenerateFeatures();
-            }
-
             // additionally, process java test files if no changes detected after a
             // different timeout
             // (but source timeout takes precedence i.e. don't recompile tests if someone


### PR DESCRIPTION
Fixes item (2) from https://github.com/OpenLiberty/ci.gradle/issues/662#issuecomment-985025788 by removing generateFeatures call during initial compile steps after dev mode startup.  Note that class files are not updated during this initial compile because they were already compiled on dev mode startup (and this initial compile's only purpose is to show compile errors if any), so feature generation does not run from the watch loop at this point.

This fix should be used along https://github.com/OpenLiberty/ci.gradle/pull/661 which handles item (1) by adding a generateFeatures call to dev mode startup steps in Gradle.