### PR TITLE
Remove unused dependencies and protect recursion in runBinaryScanner().

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,16 +56,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
             <version>1.9.9</version>

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigXmlDocument.java
@@ -30,6 +30,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Comment;
 
 public class ServerConfigXmlDocument extends XmlDocument {
+    // Formerly called src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDropinXmlDocument.java
 
     private Element featureManager = null;
 

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -55,6 +55,7 @@ public abstract class BinaryScannerUtil {
         this.binaryScanner = binaryScanner;
     }
 
+    // The first caller to this method must set currentFeatureSet to a non-null value. Null is used to control recursion.
     public Set<String> runBinaryScanner(Set<String> currentFeatureSet, List<String> classFiles, Set<String> allClassesDirectories,
             String eeVersion, String mpVersion, boolean optimize)
             throws PluginExecutionException, InvocationTargetException, NoRecommendationException, RecommendationSetException {
@@ -72,7 +73,7 @@ public abstract class BinaryScannerUtil {
 
                 String[] binaryInputs = getBinaryInputs(classFiles, allClassesDirectories, optimize);
                 List<String> currentFeatures;
-                if (currentFeatureSet == null) { // signifies we are calling the binary scanner for a sample list of features
+                if (currentFeatureSet == null) { // null signifies we are calling the binary scanner for a sample list of features
                     currentFeatures = new ArrayList<String>();
                 } else {
                     currentFeatures = new ArrayList<String>(currentFeatureSet);
@@ -87,6 +88,7 @@ public abstract class BinaryScannerUtil {
                 // A RuntimeException means the currentFeatureSet contains conflicts.
                 // A FeatureConflictException means the binary files scanned conflict with each other or with
                 // the currentFeatureSet parameter.
+                // Each analysis of the exception must consider the recursion and test currentFeatureSet == null.
                 Throwable scannerException = ite.getCause();
                 if (scannerException instanceof RuntimeException) {
                     // The list of features from the app is passed in but it contains conflicts 
@@ -94,6 +96,9 @@ public abstract class BinaryScannerUtil {
                     if (problemMessage == null || problemMessage.isEmpty()) {
                         debug("RuntimeException from binary scanner without descriptive message", scannerException);
                         error("Error scanning the application for Liberty features.");
+                    } else if (currentFeatureSet == null) {
+                        debug("Unexpected RuntimeException from binary scanner while generating suggested features", scannerException);
+                        throw ite;
                     } else {
                         Set<String> conflicts = parseScannerMessage(problemMessage);
                         Set<String> sampleFeatureList = null;


### PR DESCRIPTION
Only one more recursion check is needed on top of the new plugin exceptions added in #327 
Fixes #326
Fixes https://github.com/OpenLiberty/ci.maven/issues/1341