### PR TITLE
Wait to run tests after generate features runs on Java change

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -29,6 +29,8 @@ import java.util.Set;
 
 public abstract class BinaryScannerUtil {
 
+    public static final String GENERATED_FEATURES_FILE_NAME = "generated-features.xml";
+    public static final String GENERATED_FEATURES_FILE_PATH = "configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;
     public static final String BINARY_SCANNER_CONFLICT_MESSAGE1 = "A working set of features could not be generated due to conflicts " +
             "between configured features and the application's API usage: %s. Review and update your server configuration and " +
             "application to ensure they are not using conflicting features and APIs from different levels of MicroProfile, " +

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2833,7 +2833,15 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         javaSourceClasses.clear();
                     } else {
                         incrementGenerateFeatures();
-                        // TODO if generated file does not exist run tests
+                        File generatedFeaturesFile = new File(configDirectory, BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH);
+                        if (!generatedFeaturesFile.exists()) {
+                            // run tests if generated-features.xml does not exist as there are no new features to install
+                            if (isMultiModuleProject()) {
+                                runTestThread(false, executor, -1, false, getAllBuildFiles());
+                            } else {
+                                runTestThread(false, executor, -1, false, false, buildFile);
+                            }
+                        }
                     }
                 }
 
@@ -4037,8 +4045,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 if (isDockerfileDirectoryChanged(serverDirectory, fileChanged)) {
                     untrackDockerfileDirectoriesAndRestart();
                 }
-                  // always skip UTs
-                  runTestThread(true, executor, numApplicationUpdatedMessages, true, false, buildFile);
+                // always skip UTs
+                runTestThread(true, executor, numApplicationUpdatedMessages, true, false, buildFile);
             }
         } else if (directory.startsWith(configPath)
                 && !isGeneratedConfigFile(fileChanged, configDirectory, serverDirectory)) { // config
@@ -4076,11 +4084,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         restartServer(false);
                     }
                 }
-                if (fileChanged.getName().equals("generated-features.xml") && generateFeatures) {
+                if (fileChanged.getName().equals(BinaryScannerUtil.GENERATED_FEATURES_FILE_NAME) && generateFeatures) {
                     // if generateFeatures is true, run UTs and ITs as tests would have been skipped
                     // during recompileJava()
                     if (isMultiModuleProject()) {
-                        runTestThread(false, executor, numApplicationUpdatedMessages, false, getAllBuildFiles());
+                        runTestThread(true, executor, numApplicationUpdatedMessages, false, getAllBuildFiles());
                     } else {
                         runTestThread(true, executor, numApplicationUpdatedMessages, false, false, buildFile);
                     }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1354

With `hotTests = true` and `generateFeatures=true`, suppress unit and integration tests running after a java change. 

Instead run unit and integration tests:
1) after change is detected on `generated-features.xml` and features are installed
2) after a class file change triggers `incrementGenerateFeatures()` and `generated-features.xml` does not exist (indicating no new features were generated). 