### PR TITLE
Move binary scanner maven artifact constants to BinaryScannerUtil and bump binary scanner version

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -24,12 +24,16 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public abstract class BinaryScannerUtil {
+
+    public static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
+    public static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
+    public static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
+    public static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.5-SNAPSHOT,)";
 
     public static final String GENERATED_FEATURES_FILE_NAME = "generated-features.xml";
     public static final String GENERATED_FEATURES_FILE_PATH = "configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;


### PR DESCRIPTION
Bump lower bound of binary scanner version to `21.0.0.5-SNAPSHOT`

See https://github.com/OpenLiberty/ci.maven/issues/1321#issuecomment-1021468911 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>