### PR TITLE
Generate features when config xml file modified and features have been modified

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4029,9 +4029,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     // custom server.xml modified
                     generateFeaturesSuccess = optimizeGenerateFeatures();
                 }
-                // suppress install feature warning - property must be set before calling copyConfigFolder
+                // suppress install feature warning - property must be set before calling installFeaturesToTempDir
                 System.setProperty(SKIP_BETA_INSTALL_WARNING, Boolean.TRUE.toString());
-                // copyConfigFolder will install features if new ones are detected
                 installFeaturesToTempDir(fileChanged, serverXmlFileParent, "server.xml", generateFeaturesSuccess);
                 copyFile(fileChanged, serverXmlFileParent, serverDirectory, "server.xml");
                 
@@ -4071,9 +4070,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     generateFeaturesSuccess = false;
                     generateFeaturesSuccess = optimizeGenerateFeatures();
                 }
-                // suppress install feature warning - property must be set before calling copyConfigFolder
+                // suppress install feature warning - property must be set before calling installFeaturesToTempDir
                 System.setProperty(SKIP_BETA_INSTALL_WARNING, Boolean.TRUE.toString());
-                // copyConfigFolder will install features if new ones are detected
                 installFeaturesToTempDir(fileChanged, configDirectory, null, generateFeaturesSuccess);
                 copyFile(fileChanged, configDirectory, serverDirectory, null);
 
@@ -4368,7 +4366,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * @param targetFileName          if not null renames the fileChanged to
      *                                targetFileName in the targetDir
      * @param generateFeaturesSuccess if features were successfully generated, skip
-     *                                install features if false
+     *                                install features if false. Defaults to true if
+     *                                generateFeatures is off
      * @throws IOException creating and copying to tempConfig directory
      */
     public void installFeaturesToTempDir(File fileChanged, File srcDir, String targetFileName, boolean generateFeaturesSuccess) throws IOException {
@@ -4393,7 +4392,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         }, true);
         copyFile(fileChanged, srcDir, tempConfig, targetFileName);
         // if feature generation is on, then it should succeed before installing features
-        if (!generateFeatures || generateFeaturesSuccess) {
+        if (generateFeaturesSuccess) {
             installFeatures(fileChanged, tempConfig);
         }
         cleanUpTempConfig();

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -5434,19 +5434,18 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         // in the configDirectory
         Set<String> featuresExcludingGenerated = servUtil.getServerFeatures(configDirectory, serverXmlFile,
                 new HashMap<String, File>(), generatedFiles);
-        // compare generatedFeatures and featuresExcludingGenerated for overlap
-        if (featuresExcludingGenerated != null && generatedFeatures != null) {
-            if (!Collections.disjoint(featuresExcludingGenerated, generatedFeatures)) {
-                // indicates a generated feature has been manually added to other config files
-                return true;
-            }
+        servUtil.setSuppressLogs(false); // re-enable logs from ServerFeatureUtil
+        if (featuresExcludingGenerated != null && generatedFeatures != null
+                && !Collections.disjoint(featuresExcludingGenerated, generatedFeatures)) {
+            // indicates a generated feature has been manually added to other config files
+            return true;
         }
 
-        // if serverXmlFile is null, getServerFeatures will use the default server.xml
-        // in the configDirectory
-        Set<String> features = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                new HashMap<String, File>(), null);
-        servUtil.setSuppressLogs(false); // re-enable logs from ServerFeatureUtil
-        return servUtil.featuresModified(features, getExistingFeatures());
+        Set<String> features = featuresExcludingGenerated != null ? new HashSet<String>(featuresExcludingGenerated)
+                : new HashSet<String>();
+        if (generatedFeatures != null) {
+            features.addAll(generatedFeatures);
+        }
+        return !features.equals(getExistingFeatures());
     }
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -68,7 +68,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
 
     private Map<String, File> libertyDirectoryPropertyToFile = null;
     private boolean lowerCaseFeatures = true;
-    public boolean suppressLogs = false; // set to true when info and warning messages should not be displayed
+    protected boolean suppressLogs = false; // set to true when info and warning messages should not be displayed
     
     /**
      * Log debug
@@ -157,6 +157,16 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
      */
     public void setLowerCaseFeatures(boolean val) {
         lowerCaseFeatures = val;
+    }
+
+    /**
+     * Indicate whether the info and warning messages should not be displayed. Used
+     * as part of the dev mode flow to avoid flooding the console.
+     * 
+     * @param val boolean true to indicate that info and warning log messages should be not displayed.
+     */
+    public void setSuppressLogs(boolean val) {
+        suppressLogs = val;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -357,19 +357,17 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
     public boolean featuresModified(Set<String> currentFeatures, Set<String> existingFeatures) {
         if (currentFeatures != null) {
             // check if features have been added
-            Set<String> featuresCopy = new HashSet<String>();
-            featuresCopy.addAll(currentFeatures);
+            Set<String> currentFeaturesCopy = new HashSet<String>(currentFeatures);
             if (existingFeatures != null) {
-                featuresCopy.removeAll(existingFeatures);
+                currentFeaturesCopy.removeAll(existingFeatures);
             }
-            if (!featuresCopy.isEmpty()) {
+            if (!currentFeaturesCopy.isEmpty()) {
                 return true; // features have been added
             }
 
             // check if features have been removed
-            Set<String> existingFeaturesCopy = new HashSet<String>();
             if (existingFeatures != null) {
-                existingFeaturesCopy.addAll(existingFeatures);
+                Set<String> existingFeaturesCopy = new HashSet<String>(existingFeatures);
                 existingFeaturesCopy.removeAll(currentFeatures);
                 if (!existingFeaturesCopy.isEmpty()) {
                     return true; // features have been removed

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -345,38 +345,6 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
         return result;
     }
 
-
-    /**
-     * Compares a list of current features to a list of existing features. Returns
-     * true if features have been added or removed.
-     * 
-     * @param currentFeatures
-     * @param existingFeatures
-     * @return true if features have been modified, false if not
-     */
-    public boolean featuresModified(Set<String> currentFeatures, Set<String> existingFeatures) {
-        if (currentFeatures != null) {
-            // check if features have been added
-            Set<String> currentFeaturesCopy = new HashSet<String>(currentFeatures);
-            if (existingFeatures != null) {
-                currentFeaturesCopy.removeAll(existingFeatures);
-            }
-            if (!currentFeaturesCopy.isEmpty()) {
-                return true; // features have been added
-            }
-
-            // check if features have been removed
-            if (existingFeatures != null) {
-                Set<String> existingFeaturesCopy = new HashSet<String>(existingFeatures);
-                existingFeaturesCopy.removeAll(currentFeatures);
-                if (!existingFeaturesCopy.isEmpty()) {
-                    return true; // features have been removed
-                }
-            }
-        }
-        return false;
-    }
-    
     /**
      * Parse feature elements from a featureManager node, trimming whitespace
      * and treating everything as lowercase.

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -68,6 +68,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
 
     private Map<String, File> libertyDirectoryPropertyToFile = null;
     private boolean lowerCaseFeatures = true;
+    public boolean suppressLogs = false; // set to true when info and warning messages should not be displayed
     
     /**
      * Log debug
@@ -563,4 +564,5 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
         debug("Include location attribute property value "+ propertyValue +" replaced with "+ returnValue);
         return returnValue;
     }
+
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -344,6 +344,40 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
         }
         return result;
     }
+
+
+    /**
+     * Compares a list of current features to a list of existing features. Returns
+     * true if features have been added or removed.
+     * 
+     * @param currentFeatures
+     * @param existingFeatures
+     * @return true if features have been modified, false if not
+     */
+    public boolean featuresModified(Set<String> currentFeatures, Set<String> existingFeatures) {
+        if (currentFeatures != null) {
+            // check if features have been added
+            Set<String> featuresCopy = new HashSet<String>();
+            featuresCopy.addAll(currentFeatures);
+            if (existingFeatures != null) {
+                featuresCopy.removeAll(existingFeatures);
+            }
+            if (!featuresCopy.isEmpty()) {
+                return true; // features have been added
+            }
+
+            // check if features have been removed
+            Set<String> existingFeaturesCopy = new HashSet<String>();
+            if (existingFeatures != null) {
+                existingFeaturesCopy.addAll(existingFeatures);
+                existingFeaturesCopy.removeAll(currentFeatures);
+                if (!existingFeaturesCopy.isEmpty()) {
+                    return true; // features have been removed
+                }
+            }
+        }
+        return false;
+    }
     
     /**
      * Parse feature elements from a featureManager node, trimming whitespace

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -281,7 +281,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil {
      *         features to install, or null if there are no valid xml files or
      *         they have no featureManager section
      */
-    private Set<String> getServerXmlFeatures(Set<String> origResult, File serverFile, Properties bootstrapProperties, List<File> parsedXmls) {
+    public Set<String> getServerXmlFeatures(Set<String> origResult, File serverFile, Properties bootstrapProperties, List<File> parsedXmls) {
         Set<String> result = origResult;
         List<File> updatedParsedXmls = parsedXmls != null ? parsedXmls : new ArrayList<File>();
         File canonicalServerFile;

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -142,9 +142,15 @@ public class BaseDevUtilTest {
         }
 
         @Override
-        public boolean serverFeaturesModified(File configDirectory) {
+        public ServerFeatureUtil getServerFeatureUtilObj() {
             // not needed for tests
-            return false;
+            return null;
+        }
+
+        @Override
+        public Set<String> getExistingFeatures() {
+            // not needed for tests
+            return null;
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -137,9 +137,14 @@ public class BaseDevUtilTest {
         }
 
         @Override
-        public void checkConfigFile(File configFile, File serverDir) {
+        public void installFeatures(File configFile, File serverDir) {
             // not needed for tests
-            
+        }
+
+        @Override
+        public boolean serverFeaturesModified(File configDirectory) {
+            // not needed for tests
+            return false;
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -32,8 +32,6 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1431

On any config XML file change (added, modified, deleted, also including the `serverXmlFile` custom server.xml) check if features have been modified. If they have, call optimizeGenerateFeatures()

Renames the following methods to more descriptive names:
- `checkConfigFolder` --> `installFeaturesToTempDir`
- `checkConfigFile` --> `installFeatures`

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>