### PR TITLE
Improve log message when parsing server files for features

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -5430,7 +5430,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         ServerFeatureUtil servUtil = getServerFeatureUtilObj();
 
         // generateFeatures scenario: check if a generated feature has been manually added to other config files
-        Set<String> generatedFeatures = servUtil.getServerXmlFeatures(null,
+        Set<String> generatedFeatures = servUtil.getServerXmlFeatures(null, serverDirectory,
                 new File(configDirectory, BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH), null, null);
         Set<String> generatedFiles = new HashSet<String>();
         generatedFiles.add(BinaryScannerUtil.GENERATED_FEATURES_FILE_NAME);


### PR DESCRIPTION
Improve the "Parsing the server file for features and includes" message to list the paths relative to the server directory.

```
[INFO] CWWKM2102I: Using serverName : defaultServer.
[INFO] CWWKM2102I: Using serverDirectory : /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer.
[INFO] Parsing the server file for features and includes: defaultServer/configDropins/defaults/install_apps_configuration_1491924271.xml
[INFO] Parsing the server file for features and includes: defaultServer/server.xml
[INFO] Parsing the server file for features and includes: defaultServer/extraFeatures1.xml
[INFO] Parsing the server file for features and includes: defaultServer/extraServerConfig1.xml
[INFO] Parsing the server file for features and includes: defaultServer/configDropins/overrides/generated-features.xml
[INFO] Parsing the server file for features and includes: defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml
[INFO] Installing features: [mphealth-3.1, cdi-2.0, jaxrs-2.1]
```
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>