### PR TITLE
If needed copy the generated-features.xml file to the server directory on config file change

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4121,7 +4121,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     installFeaturesToTempDir(fileChanged, serverXmlFileParent, "server.xml", generateFeaturesSuccess);
                 }
                 copyFile(fileChanged, serverXmlFileParent, serverDirectory, "server.xml");
-
+                if (generateFeaturesSuccess && generatedFeaturesModified) {
+                    // copy generated-features.xml file to server dir
+                    copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
+                    generatedFeaturesModified = false;
+                }
                 if (isDockerfileDirectoryChanged(serverDirectory, fileChanged)) {
                     untrackDockerfileDirectoriesAndRestart();
                 } else if (changeType == ChangeType.CREATE) {
@@ -4172,7 +4176,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     debug("The features in " + generatedFeaturesFile + " have not been modified.");
                 } else {
                     copyFile(fileChanged, configDirectory, serverDirectory, null);
-                    generatedFeaturesModified = false;
+                    if (generateFeaturesSuccess && generatedFeaturesModified) {
+                        // copy generated-features.xml file to server dir
+                        copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
+                        generatedFeaturesModified = false;
+                    }
                 }
 
                 if (isDockerfileDirectoryChanged(serverDirectory, fileChanged)) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4177,7 +4177,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     debug("The features in " + generatedFeaturesFile + " have not been modified.");
                 } else {
                     copyFile(fileChanged, configDirectory, serverDirectory, null);
-                    if (generateFeaturesSuccess && generatedFeaturesModified) {
+                    // if the generated features file changed, copy it over to target along with the changed config file so the server picks up the changes together
+                    if (generateFeaturesSuccess && generatedFeaturesModified) { 
                         // copy generated-features.xml file to server dir
                         copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
                         generatedFeaturesModified = false;

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4121,9 +4121,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     installFeaturesToTempDir(fileChanged, serverXmlFileParent, "server.xml", generateFeaturesSuccess);
                 }
                 copyFile(fileChanged, serverXmlFileParent, serverDirectory, "server.xml");
-                // if the generated features file changed, copy it over to target along with the changed server.xml file so the server picks up the changes together
+                // if the generated features file was modified as a result of the server.xml
+                // file modification, copy it over to target so the server picks up the changes
+                // together
                 if (generateFeaturesSuccess && generatedFeaturesModified) {
-                    // copy generated-features.xml file to server dir
+                    // copy generated features file to server dir
                     copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
                     generatedFeaturesModified = false;
                 }
@@ -4158,7 +4160,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 boolean serverFeaturesModified = serverFeaturesModified();
                 boolean isGeneratedFeaturesFile = fileChanged.equals(generatedFeaturesFile);
                 // generate features whenever features have changed and an XML file is modified,
-                // excluding the generated-features.xml file
+                // excluding the generated features file
                 if (generateFeatures && (fileChanged.getName().endsWith(".xml")
                         && !isGeneratedFeaturesFile)
                         && serverFeaturesModified) {
@@ -4172,14 +4174,17 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     installFeaturesToTempDir(fileChanged, configDirectory, null, generateFeaturesSuccess);
                 }
                 if (isGeneratedFeaturesFile && !generatedFeaturesModified) {
-                    // features in the generated-features.xml file did not change, do not copy this file
+                    // features in the generated features file did not change, do not copy this file
                     // to the server directory
                     debug("The features in " + generatedFeaturesFile + " have not been modified.");
                 } else {
                     copyFile(fileChanged, configDirectory, serverDirectory, null);
-                    // if the generated features file changed, copy it over to target along with the changed config file so the server picks up the changes together
-                    if (generateFeaturesSuccess && generatedFeaturesModified) { 
-                        // copy generated-features.xml file to server dir
+                    // if the generated features file was modified as a result of another config
+                    // file modification, copy it over to target so the server picks up the changes
+                    // together
+                    if (generateFeaturesSuccess && generatedFeaturesModified) {
+                        // this logic is not entered if the fileChanged is the generated features file
+                        // copy generated features file to server dir
                         copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
                         generatedFeaturesModified = false;
                     }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4121,6 +4121,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     installFeaturesToTempDir(fileChanged, serverXmlFileParent, "server.xml", generateFeaturesSuccess);
                 }
                 copyFile(fileChanged, serverXmlFileParent, serverDirectory, "server.xml");
+                // if the generated features file changed, copy it over to target along with the changed server.xml file so the server picks up the changes together
                 if (generateFeaturesSuccess && generatedFeaturesModified) {
                     // copy generated-features.xml file to server dir
                     copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1512

Copy the generated-features.xml file to the server directory on server.xml or other xml config file changes if the generated features have changed.

Updated logic flow is:
1. server.xml (or another server configuration xml file) updated, FileWatcher indicates a server config file has been modified
2. features are generated
3. copy server.xml and generated-features.xml to temp server dir
4. install features given the temp server dir
5. copy the server.xml to the target dir
6. if the features in generated-features.xml file have changed, copy the generated-features.xml file to target dir 
7. FileWatcher indicates that the generated-features.xml file has been modified, however the features have not changed so do not copy the file to target dir again

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>