### PR TITLE
Display the action letter before the description of the action.

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2320,8 +2320,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         if (!inputUnavailable) {
             if (startup) {
                 // the following will be printed only on startup or restart
-                info(formatAttentionMessage("To see the help menu for available actions, type 'h' and press Enter."));
-                info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+                info(formatAttentionMessage("h - To see the help menu for available actions, type 'h' and press Enter."));
+                info(formatAttentionMessage("q - To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
             } else {
                 // the following will be printed every time after the tests run
                 printTestsMessage(false);
@@ -2329,7 +2329,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         } else {
             debug("Cannot read user input, setting hotTests to true.");
             String message = "Tests will run automatically when changes are detected.";
-            info(startup ? formatAttentionMessage(message) : message);
+            info(startup ? formatAttentionMessage("Enter - " + message) : message);
             hotTests = true;
         }
         if (startup) {
@@ -2411,10 +2411,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     private void printTestsMessage(boolean formatForAttention) {
         if (hotTests) {
             String message = "Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.";
-            info(formatForAttention ? formatAttentionMessage(message) : message);
+            info(formatForAttention ? formatAttentionMessage("Enter - " + message) : message);
         } else {
             String message = "To run tests on demand, press Enter.";
-            info(formatForAttention ? formatAttentionMessage(message) : message);
+            info(formatForAttention ? formatAttentionMessage("Enter - " + message) : message);
         }
     }
 
@@ -2423,12 +2423,12 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         printFeatureGenerationHotkeys();
         printTestsMessage(true);
         if (container) {
-            info(formatAttentionMessage("To rebuild the Docker image and restart the container, type 'r' and press Enter."));
+            info(formatAttentionMessage("r - To rebuild the Docker image and restart the container, type 'r' and press Enter."));
         } else {
-            info(formatAttentionMessage("To restart the server, type 'r' and press Enter."));
+            info(formatAttentionMessage("r - To restart the server, type 'r' and press Enter."));
         }
-        info(formatAttentionMessage("To see the help menu for available actions, type 'h' and press Enter."));
-        info(formatAttentionMessage("To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+        info(formatAttentionMessage("h - To see the help menu for available actions, type 'h' and press Enter."));
+        info(formatAttentionMessage("q - To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
     }
 
     private void printFeatureGenerationStatus() {
@@ -2436,10 +2436,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     private void printFeatureGenerationHotkeys() {
-        info(formatAttentionMessage("To toggle the automatic generation of features, type 'g' and press Enter."));
+        info(formatAttentionMessage("g - To toggle the automatic generation of features, type 'g' and press Enter."));
         if (generateFeatures) {
             // If generateFeatures is enabled, then also describe the optimize hotkey
-            info(formatAttentionMessage("To optimize the list of generated features, type 'o' and press Enter."));
+            info(formatAttentionMessage("o - To optimize the list of generated features, type 'o' and press Enter."));
         }
     }
 
@@ -2550,6 +2550,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             HotKey r = new HotKey("r");
             HotKey g = new HotKey("g");
             HotKey o = new HotKey("o");
+            HotKey enter = new HotKey("");
             if (scanner.hasNextLine()) {
                 synchronized (inputUnavailable) {
                     inputUnavailable.notify();
@@ -2585,7 +2586,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                             warn("Cannot optimize features because automatic generation of features is off.");
                             warn("To toggle the automatic generation of features, type 'g' and press Enter.");
                         }
-                    } else {
+                    } else if (enter.isPressed(line)){
                         debug("Detected Enter key. Running tests... ");
                         if (isMultiModuleProject()) {
                             // force run tests across all modules in multi module scenario
@@ -2593,6 +2594,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         } else {
                             runTestThread(false, executor, -1, true, buildFile);
                         }
+                    } else {
+                        warn("Unrecognized command: " + line + ". To see the help menu, type 'h' and press Enter.");
                     }
                 }
             } else {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2320,8 +2320,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         if (!inputUnavailable) {
             if (startup) {
                 // the following will be printed only on startup or restart
-                info(formatAttentionMessage("h - To see the help menu for available actions, type 'h' and press Enter."));
-                info(formatAttentionMessage("q - To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+                info(formatAttentionMessage("h - see the help menu for available actions, type 'h' and press Enter."));
+                info(formatAttentionMessage("q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
             } else {
                 // the following will be printed every time after the tests run
                 printTestsMessage(false);
@@ -2413,8 +2413,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             String message = "Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.";
             info(formatForAttention ? formatAttentionMessage("Enter - " + message) : message);
         } else {
-            String message = "To run tests on demand, press Enter.";
-            info(formatForAttention ? formatAttentionMessage("Enter - " + message) : message);
+            String message = "run tests on demand, press Enter.";
+            info(formatForAttention ? formatAttentionMessage("Enter - " + message) : "To " + message);
         }
     }
 
@@ -2423,12 +2423,12 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         printFeatureGenerationHotkeys();
         printTestsMessage(true);
         if (container) {
-            info(formatAttentionMessage("r - To rebuild the Docker image and restart the container, type 'r' and press Enter."));
+            info(formatAttentionMessage("r - rebuild the Docker image and restart the container, type 'r' and press Enter."));
         } else {
-            info(formatAttentionMessage("r - To restart the server, type 'r' and press Enter."));
+            info(formatAttentionMessage("r - restart the server, type 'r' and press Enter."));
         }
-        info(formatAttentionMessage("h - To see the help menu for available actions, type 'h' and press Enter."));
-        info(formatAttentionMessage("q - To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
+        info(formatAttentionMessage("h - see the help menu for available actions, type 'h' and press Enter."));
+        info(formatAttentionMessage("q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter."));
     }
 
     private void printFeatureGenerationStatus() {
@@ -2436,10 +2436,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     private void printFeatureGenerationHotkeys() {
-        info(formatAttentionMessage("g - To toggle the automatic generation of features, type 'g' and press Enter."));
+        info(formatAttentionMessage("g - toggle the automatic generation of features, type 'g' and press Enter."));
         if (generateFeatures) {
             // If generateFeatures is enabled, then also describe the optimize hotkey
-            info(formatAttentionMessage("o - To optimize the list of generated features, type 'o' and press Enter."));
+            info(formatAttentionMessage("o - optimize the list of generated features, type 'o' and press Enter."));
         }
     }
 


### PR DESCRIPTION
Also, display warning when action is unrecognised.

Fixes  https://github.com/OpenLiberty/ci.maven/issues/1446

`Enter - Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.` is difficult to reword. This message appears when `hotTests` is on so you don't usually press Enter to run the tests. I think the most important part of this message is to say tests run automatically. The second most important part is to press Enter to run the tests again on demand. 
```
[INFO] ************************************************************************
[INFO] *        Automatic generation of features: [ On ]
[INFO] *        g - toggle the automatic generation of features, type 'g' and press Enter.
[INFO] *        o - optimize the list of generated features, type 'o' and press Enter.
[INFO] *        Enter - run tests on demand, press Enter.
[INFO] *        r - restart the server, type 'r' and press Enter.
[INFO] *        h - see the help menu for available actions, type 'h' and press Enter.
[INFO] *        q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************
```
```
[INFO] Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.
h
[INFO] ************************************************************************
[INFO] *        Automatic generation of features: [ On ]
[INFO] *        g - toggle the automatic generation of features, type 'g' and press Enter.
[INFO] *        o - optimize the list of generated features, type 'o' and press Enter.
[INFO] *        Enter - Tests will run automatically when changes are detected. You can also press the Enter key to run tests on demand.
[INFO] *        r - restart the server, type 'r' and press Enter.
[INFO] *        h - see the help menu for available actions, type 'h' and press Enter.
[INFO] *        q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************```