### PR TITLE
Update existing feature list even if install feature was unsuccessful

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -273,6 +273,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     public abstract Set<String> getExistingFeatures();
 
     /**
+     * Update existing features set
+     */
+    public abstract void updateExistingFeatures();
+
+    /**
      * Compile the specified directory
      * 
      * @param dir
@@ -4145,6 +4150,10 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
                     generatedFeaturesModified = false;
                 }
+                if (serverFeaturesModified) {
+                    updateExistingFeatures();
+                }
+
                 if (isDockerfileDirectoryChanged(serverDirectory, fileChanged)) {
                     untrackDockerfileDirectoriesAndRestart();
                 } else if (changeType == ChangeType.CREATE) {
@@ -4197,6 +4206,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     // copy generated features file to server dir
                     copyFile(generatedFeaturesFile, configDirectory, serverDirectory, null);
                     generatedFeaturesModified = false;
+                }
+                if (serverFeaturesModified) {
+                    updateExistingFeatures();
                 }
 
                 if (isDockerfileDirectoryChanged(serverDirectory, fileChanged)) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4227,7 +4227,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     /**
      * Process a configuration file change.
      * 
-     * Typical sequence of events when config file is created/modfiied:
+     * Typical sequence of events when config file is created/modified:
      * 1. Generate features
      * 2. Install features if features were modified
      * 3. Copy fileChanged (and generated features file if modified in step 1) to

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -273,7 +273,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     public abstract Set<String> getExistingFeatures();
 
     /**
-     * Update existing features set
+     * Update the existing features list using the files in the server directory.
+     * Called on configuration file change to ensure we have the most current
+     * feature list.
      */
     public abstract void updateExistingFeatures();
 

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -154,6 +154,11 @@ public class BaseDevUtilTest {
         }
 
         @Override
+        public void updateExistingFeatures() {
+            // not needed for tests
+        }
+
+        @Override
         public boolean compile(File dir) {
             // not needed for tests
             return false;


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1513

Much of the logic for a configuration file change or a configured custom server.xml file (serverXmlFile configuration parameter) is the same. Refactored this logic into a common method.
 
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>