### PR TITLE
Add warning messages for generate features generating to source dir

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2444,10 +2444,14 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     private void printFeatureGenerationHotkeys() {
         info(formatAttentionMessage(
-                "g - toggle the automatic generation of features, type 'g' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory."));
+                "g - toggle the automatic generation of features, type 'g' and press Enter."));
+        info(formatAttentionMessage(
+                "    A new server configuration file will be generated in the SOURCE configDropins/overrides configuration directory."));
         if (generateFeatures) {
             // If generateFeatures is enabled, then also describe the optimize hotkey
-            info(formatAttentionMessage("o - optimize the list of generated features, type 'o' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory."));
+            info(formatAttentionMessage("o - optimize the list of generated features, type 'o' and press Enter."));
+            info(formatAttentionMessage(
+                    "    A new server configuration file will be generated in the SOURCE configDropins/overrides configuration directory."));
         }
     }
 

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2443,10 +2443,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     }
 
     private void printFeatureGenerationHotkeys() {
-        info(formatAttentionMessage("g - toggle the automatic generation of features, type 'g' and press Enter."));
+        info(formatAttentionMessage(
+                "g - toggle the automatic generation of features, type 'g' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory."));
         if (generateFeatures) {
             // If generateFeatures is enabled, then also describe the optimize hotkey
-            info(formatAttentionMessage("o - optimize the list of generated features, type 'o' and press Enter."));
+            info(formatAttentionMessage("o - optimize the list of generated features, type 'o' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory."));
         }
     }
 
@@ -2470,6 +2471,13 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         generateFeatures = !generateFeatures;
         logFeatureGenerationStatus();
         if (generateFeatures) {
+            String generatedFileCanonicalPath;
+            try {
+                generatedFileCanonicalPath = new File(configDirectory, BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH).getCanonicalPath();
+            } catch (IOException e) {
+                generatedFileCanonicalPath = new File(configDirectory, BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH).toString();
+            }
+            warn("The source configuration directory will be modified. Features will automatically be generated in a new file: " + generatedFileCanonicalPath);
             // If hotkey is toggled to “true”, generate features right away.
             optimizeGenerateFeatures();
         }


### PR DESCRIPTION
Toggling generate features on after dev mode as started:
```
h
[INFO] ************************************************************************
[INFO] *        Automatic generation of features: [ Off ]
[INFO] *        g - toggle the automatic generation of features, type 'g' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory.
[INFO] *        Enter - run tests on demand, press Enter.
[INFO] *        r - restart the server, type 'r' and press Enter.
[INFO] *        h - see the help menu for available actions, type 'h' and press Enter.
[INFO] *        q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************
g
[INFO] Setting automatic generation of features to: [ On ]
[WARNING] The source configuration directory will be modified. Features will automatically be generated in a new file: /Users/kathrynkodama/devex/sampleProjects/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml
[INFO] Running liberty:generate-features
[INFO] Regenerated the following features: [cdi-2.0, mpMetrics-3.0, jaxrs-2.1]
```

Starting dev mode with `generateFeatures=true`:
```
[WARNING] The source configuration directory will be modified. Features will automatically be generated in a new file: /Users/kathrynkodama/devex/sampleProjects/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml
[INFO] Running liberty:generate-features
[INFO] Regenerated the following features: [cdi-2.0, mpMetrics-3.0, jaxrs-2.1]
[INFO] Running liberty:create
...

h
[INFO] ************************************************************************
[INFO] *        Automatic generation of features: [ On ]
[INFO] *        g - toggle the automatic generation of features, type 'g' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory.
[INFO] *        o - optimize the list of generated features, type 'o' and press Enter. A new server configuration file will be generated in the SOURCE configuration directory.
[INFO] *        Enter - run tests on demand, press Enter.
[INFO] *        r - restart the server, type 'r' and press Enter.
[INFO] *        h - see the help menu for available actions, type 'h' and press Enter.
[INFO] *        q - stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] ************************************************************************

```
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>