### PR TITLE
Fix file comparison for generated features file

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3916,9 +3916,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                             TrueFileFilter.INSTANCE);
                     if (it.hasNext()) {
                         File newlyRegisteredFile = it.next();
-                        // confirm that the newly registered file is in configDropins/overrides
-                        if (newlyRegisteredFile.getCanonicalPath()
-                                .endsWith(BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH)) {
+                        // confirm that the newly registered file is generated features file in configDropins/overrides
+                        if (newlyRegisteredFile.equals(generatedFeaturesFile)) {
                             // process file changes for the generated features file so that newly generated features are installed
                             debug("Registered configDropins/overrides directory, processing file changes for generated features file: "
                                     + newlyRegisteredFile);


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1545

Previous file path comparison was not valid for Windows

Confirmed that this fix is valid for MacOS


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>