### PR TITLE
Compose version parameters for binary scanner and handle errors

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -388,7 +388,7 @@ public abstract class BinaryScannerUtil {
      * E.g. mp1.3, mp4.1 etc
      * @param ver the String value version number read from the build file (pom.xml, build.gradle)
      *           E.g. 1, 2.1 etc. This is verified by the parser and cannot be blank.
-     * @return String parameter passed to binary scanner or empty string in case of error
+     * @return String parameter passed to binary scanner or null in case of error
      */
     public static String composeMPVersion(String ver) {
         int offset = ver.indexOf("-RC"); // clean up 4.1-RC to 4.1
@@ -396,11 +396,15 @@ public abstract class BinaryScannerUtil {
             ver = ver.substring(0, offset);
         }
         String[] parts = ver.split("\\.", 3); // binary scanner only recognises the first two values. Regex for "." char
+        // TODO: remove extra handling for v5 once issue 1551 is fixed
+        if ("5".equals(parts[0])) {
+            return BINARY_SCANNER_MP_PREFIX + parts[0];
+        }
         if (parts.length > 1 &&
                 parts[0] != null && !parts[0].isEmpty() && parts[1] != null && !parts[1].isEmpty()) {
             return BINARY_SCANNER_MP_PREFIX + parts[0] + "." + parts[1];
         }
-        return "";
+        return null;
     }
 
     // A class to pass the list of conflicts back to the caller.

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -396,10 +396,6 @@ public abstract class BinaryScannerUtil {
             ver = ver.substring(0, offset);
         }
         String[] parts = ver.split("\\.", 3); // binary scanner only recognises the first two values. Regex for "." char
-        // TODO: remove extra handling for v5 once issue 1551 is fixed
-        if ("5".equals(parts[0])) {
-            return BINARY_SCANNER_MP_PREFIX + parts[0];
-        }
         if (parts.length > 1 &&
                 parts[0] != null && !parts[0].isEmpty() && parts[1] != null && !parts[1].isEmpty()) {
             return BINARY_SCANNER_MP_PREFIX + parts[0] + "." + parts[1];

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -53,6 +53,10 @@ public abstract class BinaryScannerUtil {
     public static final String BINARY_SCANNER_CONFLICT_MESSAGE5 = "A working set of features could not be generated due to conflicts " + 
             "in the required features: %s and required levels of MicroProfile: %s, Java EE or Jakarta EE: %s. Review and update your application to ensure it " + 
             "is using the correct levels of MicroProfile, Java EE, or Jakarta EE, or consider removing the following set of features: %s.";
+    public static final String BINARY_SCANNER_INVALID_MP_MESSAGE = "The MicroProfile version number specified in the build file " +
+            "is not supported for feature generation.";
+    public static final String BINARY_SCANNER_INVALID_EE_MESSAGE = "The Java EE or Jakarta EE version number specified in the build file " +
+            "is not supported for feature generation.";
 
     // Strings recognized by the binary scanner arguments for Java/Jakarta EE and MicroProfile
     // Valid ee6, ee7, ee8, ee9 and so on
@@ -183,14 +187,13 @@ public abstract class BinaryScannerUtil {
                     throw new FeatureUnavailableException(conflicts, unavailableFeatures, targetMicroProfile,
                             targetJavaEE);
                 } else if (scannerException.getClass().getName().contains("java.lang.IllegalArgumentException")) {
+                    // TODO: Affected by issue #1558
                     String msg = scannerException.getMessage();
                     if (msg.contains("CWMIG12056E")) {
                         if (msg.contains("targetJavaEE")) {
-                            throw new PluginExecutionException("The Java EE or Jakarta EE version number specified in the build file " +
-                                    "is not supported for feature generation.");
+                            throw new PluginExecutionException(BINARY_SCANNER_INVALID_EE_MESSAGE);
                         } else if (msg.contains("targetMicroProfile")) {
-                            throw new PluginExecutionException("The MicroProfile version number specified in the build file " +
-                                    "is not supported for feature generation.");
+                            throw new PluginExecutionException(BINARY_SCANNER_INVALID_MP_MESSAGE);
                         }
                     }
                     // otherwise execute default behaviour.

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -391,7 +391,7 @@ public abstract class BinaryScannerUtil {
      * @return String parameter passed to binary scanner or empty string in case of error
      */
     public static String composeMPVersion(String ver) {
-        int offset = ver.indexOf("-RC"); // clean up input data
+        int offset = ver.indexOf("-RC"); // clean up 4.1-RC to 4.1
         if (offset > 0) {
             ver = ver.substring(0, offset);
         }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -63,8 +63,6 @@ public abstract class BinaryScannerUtil {
     public static final String BINARY_SCANNER_EE_PREFIX = "ee";
     // Valid mp1, mp1.2, mp1.3 and so on
     public static final String BINARY_SCANNER_MP_PREFIX = "mp";
-    // represents an EE or MP version higher than any of our stored versions
-    public static final String BINARY_SCANNER_UMBRELLA_DEP_MAXV = "zz10";
 
     public abstract void debug(String message);
     public abstract void debug(String message, Throwable e);


### PR DESCRIPTION
Instead of hard coding the parameters passed to the binary scanner we will compose the parameter from the information in the build file. If the build file specifies a version number that the binary scanner does not support it will throw an invalid argument exception which we report.

This pull request is also a bit of a design review. We could request a better API from the binary scanner regarding invalid version numbers but the current arrangement looks pretty safe. Also the message we report should be reviewed.