### PR TITLE
Add support for the binary scanner checking the validity of the target versions for ee and mp

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -412,6 +412,9 @@ public abstract class BinaryScannerUtil {
      * @return String parameter passed to binary scanner
      */
     public static String composeEEVersion(String ver) {
+        if (ver == null) {
+            return null;
+        }
         String majorVersion;
         int offset = ver.indexOf(".");
         majorVersion = (offset == -1) ? ver : ver.substring(0, offset);
@@ -426,6 +429,9 @@ public abstract class BinaryScannerUtil {
      * @return String parameter passed to binary scanner or null in case of error
      */
     public static String composeMPVersion(String ver) {
+        if (ver == null) {
+            return null;
+        }
         int offset = ver.indexOf("-RC"); // clean up 4.1-RC to 4.1
         if (offset > 0) {
             ver = ver.substring(0, offset);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -444,6 +444,39 @@ public abstract class BinaryScannerUtil {
         return null;
     }
 
+    /**
+     * Convenience method to build the string reported to the user when the exception is detected.
+     * 
+     * This is used after the caller has analyzed the Java or Jakarta EE version number and the MicroProfile
+     * version number and generated argument values to pass to the binary scanner. If the binary scanner
+     * detects a problem and throws an exception it reports the invalid arguments. We must map the invalid
+     * arguments back to the user specified version number in order to fix the problem.
+     * 
+     * @param invalidEEArg - the argument passed to the binary scanner which may be returned as invalid.
+     * @param invalidMPArg - the argument passed to the binary scanner which may be returned as invalid.
+     * @param eeVersion - the user specified version string from the build file used to generate the arg.
+     * @param mpVersion - the user specified version string from the build file used to generate the arg.
+     * @return a string we can report to the user to report an error or errors and guide the effort to fix it.
+     */
+    public static String buildInvalidArgExceptionMessage(String invalidEEArg, String invalidMPArg, String eeVersion, String mpVersion) {
+        String messages = null;
+        if (invalidEEArg != null) {
+            messages = String.format(BINARY_SCANNER_INVALID_EE_MESSAGE, eeVersion);
+        }
+        if (invalidMPArg != null) {
+            if (messages != null) {
+                messages += "\n" ;
+                messages += String.format(BINARY_SCANNER_INVALID_MP_MESSAGE, mpVersion);
+            } else {
+                messages = String.format(BINARY_SCANNER_INVALID_MP_MESSAGE, mpVersion);
+            }
+        }
+        if (messages == null) { // We need to be prepared for this situation from the binary scanner.
+            messages = BINARY_SCANNER_INVALID_EEMPARG_MESSAGE;
+        }
+        return messages;
+    }
+
     // A class to pass the list of conflicts back to the caller.
     public class NoRecommendationException extends Exception {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -529,12 +529,11 @@ public abstract class BinaryScannerUtil {
         }
     }
 
-    // A class to pass the invalid EE and MP parameters back to the caller.
-    public class IllegalTargetException extends Exception {
+    public abstract class AbstractIllegalTargetException extends Exception {
         private static final long serialVersionUID = 1L;
         String eeLevel;
         String mpLevel;
-        IllegalTargetException(String eeLevel, String mpLevel) {
+        AbstractIllegalTargetException(String eeLevel, String mpLevel) {
             this.eeLevel = eeLevel;
             this.mpLevel = mpLevel;
         }
@@ -546,20 +545,19 @@ public abstract class BinaryScannerUtil {
         }
     }
 
-    // A class to pass the EE and MP parameters which do not work together back to the caller.
-    public class IllegalTargetComboException extends Exception {
+    // A class to pass the invalid EE and MP parameters back to the caller.
+    public class IllegalTargetException extends AbstractIllegalTargetException {
         private static final long serialVersionUID = 1L;
-        String eeLevel;
-        String mpLevel;
+        IllegalTargetException(String eeLevel, String mpLevel) {
+            super(eeLevel, mpLevel);
+        }
+    }
+
+    // A class to pass the EE and MP parameters which do not work together back to the caller.
+    public class IllegalTargetComboException extends AbstractIllegalTargetException {
+        private static final long serialVersionUID = 1L;
         IllegalTargetComboException(String eeLevel, String mpLevel) {
-            this.eeLevel = eeLevel;
-            this.mpLevel = mpLevel;
-        }
-        public String getEELevel() {
-            return eeLevel;
-        }
-        public String getMPLevel() {
-            return mpLevel;
+            super(eeLevel, mpLevel);
         }
     }
 }


### PR DESCRIPTION
This support will be added in the 22.0.0.4 (or later) version of the binary scanner and this code continues to work with the 22.0.0.3 version which is currently available.