### PR TITLE
write liberty-dev-metadata when using devc

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -401,8 +401,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     private final boolean container;
     private String imageName;
     private String containerName;
-    private Timestamp containerStartTimestamp;
-    private Timestamp containerStopTimestamp;
+    protected String containerStartTimestamp;
+    protected String containerStopTimestamp;
     private File dockerfile;
     private File dockerBuildContext;
     private Path tempDockerfilePath = null;
@@ -1395,7 +1395,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         });
         logCopyErrorThread.start();
 
-        containerStartTimestamp = Timestamp.from(Instant.now());
+        containerStartTimestamp = Timestamp.from(Instant.now()).toString();
         writeDevcMetadata();
         if (timeout == 0) {
             startingProcess.waitFor();
@@ -1411,7 +1411,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             debug("Unexpected exit running docker command, return value=" + startingProcess.exitValue());
             // show first message from standard err
             String errorMessage = new String(firstErrorLine).trim() + " RC=" + startingProcess.exitValue();
-            containerStopTimestamp = Timestamp.from(Instant.now());
+            containerStopTimestamp = Timestamp.from(Instant.now()).toString();
             writeDevcMetadata();
             throw new RuntimeException(errorMessage);
         }
@@ -1516,7 +1516,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 String dockerStopCmd = "docker stop " + containerName;
                 debug("Stopping container " + containerName);
                 execDockerCmd(dockerStopCmd, DOCKER_TIMEOUT + 20); // allow extra time for server shutdown
-                containerStopTimestamp = Timestamp.from(Instant.now());
+                containerStopTimestamp = Timestamp.from(Instant.now()).toString();
                 writeDevcMetadata();
             }
         } catch (RuntimeException r) {
@@ -5658,12 +5658,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
      * Create metadata when running devc mode and containers
      * Language server then uses metadata file to connect
      * 
-     * @throws XMLStreamException
-     * @throws IOException
-     * @throws FactoryConfigurationError
      */
     public void writeDevcMetadata() {
-        File metaFile = new File(serverDirectory, "liberty-dev-metadata.xml");
+        File metaFile = new File(buildDirectory, serverDirectory.getName() + "-liberty-devc-metadata.xml");
         try {
             XMLStreamWriter metadataWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(new FileWriter(metaFile)) ;
             metadataWriter.writeStartDocument();

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -47,7 +47,6 @@ public class BaseDevUtilTest {
             super(buildDir, serverDirectory, null, null, null, null, null,
                     null, false, false, false, false, null, 30, 30, 5, 500, true, false, false, false,
                     false, null, null, null, 0, false, null, false, null, null, false, null, null, null, false, null, null, null);
-            this.setContainerTimestamps();
         }
 
         @Override
@@ -257,11 +256,6 @@ public class BaseDevUtilTest {
 		protected void resourceDeleted(File fileChanged, File resourceParent, File outputDirectory) throws IOException {
 			// not needed for tests
 		}
-
-        public void setContainerTimestamps() {
-            super.containerStartTimestamp = "start";
-            super.containerStopTimestamp = "stop";
-        }
     }
     
     public DevUtil getNewDevUtil(File serverDirectory) throws IOException  {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseDevUtilTest.java
@@ -43,6 +43,13 @@ public class BaseDevUtilTest {
                     false, null, null, null, 0, false, null, false, null, null, false, null, null, null, false, null, null, webResourceDirs);
         }
 
+        public DevTestUtil(File serverDirectory, File buildDir) {
+            super(buildDir, serverDirectory, null, null, null, null, null,
+                    null, false, false, false, false, null, 30, 30, 5, 500, true, false, false, false,
+                    false, null, null, null, 0, false, null, false, null, null, false, null, null, null, false, null, null, null);
+            this.setContainerTimestamps();
+        }
+
         @Override
         public void debug(String msg) {
             // not needed for tests
@@ -250,9 +257,18 @@ public class BaseDevUtilTest {
 		protected void resourceDeleted(File fileChanged, File resourceParent, File outputDirectory) throws IOException {
 			// not needed for tests
 		}
+
+        public void setContainerTimestamps() {
+            super.containerStartTimestamp = "start";
+            super.containerStopTimestamp = "stop";
+        }
     }
     
     public DevUtil getNewDevUtil(File serverDirectory) throws IOException  {
         return new DevTestUtil(serverDirectory, null, null, null, null, null, false, false);
+    }
+
+    public DevUtil getNewDevUtil(File serverDirectory, File buildDir) {
+        return new DevTestUtil(serverDirectory, buildDir);
     }
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -532,12 +532,13 @@ public class DevUtilTest extends BaseDevUtilTest {
 
     @Test
     public void testWriteDevcMetadataSimple() throws XMLStreamException, FactoryConfigurationError, IOException {
+        util = getNewDevUtil(serverDirectory, targetDir);
         util.writeDevcMetadata();
-        File metaDataXml = new File(serverDirectory, "liberty-dev-metadata.xml");
+        File metaDataXml = new File(targetDir, serverDirectory.getName() + "-liberty-devc-metadata.xml");
         assertTrue(metaDataXml.exists());
         String content = FileUtils.readFileToString(metaDataXml, "UTF-8");
-        // assertTrue(content.contains("<startTime>"));
         assertTrue(content.contains("<containerName>liberty-dev</containerName"));
-        assertFalse(content.contains("<stopTime>") || content.contains("</stopTime>"));
+        assertTrue(content.contains("<startTime>start</startTime>"));
+        assertTrue(content.contains("<stopTime>stop</stopTime>"));
     }
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -36,6 +36,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -527,5 +530,14 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertEquals(omitFiles, util.getOmitFilesList(looseAppFile, new File("/src/main/webapp").getCanonicalPath()));
     }
 
-
+    @Test
+    public void testWriteDevcMetadataSimple() throws XMLStreamException, FactoryConfigurationError, IOException {
+        util.writeDevcMetadata();
+        File metaDataXml = new File(serverDirectory, "liberty-dev-metadata.xml");
+        assertTrue(metaDataXml.exists());
+        String content = FileUtils.readFileToString(metaDataXml, "UTF-8");
+        // assertTrue(content.contains("<startTime>"));
+        assertTrue(content.contains("<containerName>liberty-dev</containerName"));
+        assertFalse(content.contains("<stopTime>") || content.contains("</stopTime>"));
+    }
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -533,12 +533,16 @@ public class DevUtilTest extends BaseDevUtilTest {
     @Test
     public void testWriteDevcMetadataSimple() throws XMLStreamException, FactoryConfigurationError, IOException {
         util = getNewDevUtil(serverDirectory, targetDir);
-        util.writeDevcMetadata();
+        util.writeDevcMetadata(true);
         File metaDataXml = new File(targetDir, serverDirectory.getName() + "-liberty-devc-metadata.xml");
         assertTrue(metaDataXml.exists());
         String content = FileUtils.readFileToString(metaDataXml, "UTF-8");
         assertTrue(content.contains("<containerName>liberty-dev</containerName"));
-        assertTrue(content.contains("<startTime>start</startTime>"));
-        assertTrue(content.contains("<stopTime>stop</stopTime>"));
+        assertTrue(content.contains("<containerAlive>true</containerAlive>"));
+
+        util.writeDevcMetadata(false);
+        content = FileUtils.readFileToString(metaDataXml, "UTF-8");
+        assertTrue(content.contains("<containerName>liberty-dev</containerName"));
+        assertTrue(content.contains("<containerAlive>false</containerAlive>"));
     }
 }


### PR DESCRIPTION
Screenshot demonstrated with the liberty starter-app

File is written out to `{buildDir}/{serverName}-liberty-devc-metadata.xml`
The original file gets replaced if/when written to the same place when stopped.

![image](https://user-images.githubusercontent.com/8934136/186494990-f89c10e3-8a18-427b-bcca-5a2025b78722.png)
