### PR TITLE
Enable schema regen for Liberty Tools

### DIFF
--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
@@ -36,6 +36,7 @@ public class BaseInstallFeatureUtilTest {
     private static final String RESOURCES_INSTALL_DIR = RESOURCES_DIR + "/installdir";
     
     public File installDir;
+    public File buildDir;
     
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
@@ -45,11 +46,13 @@ public class BaseInstallFeatureUtilTest {
         installDir = temp.newFolder();
         File src = new File(RESOURCES_INSTALL_DIR);
         FileUtils.copyDirectory(src, installDir);
+
+        buildDir = temp.newFolder();
     }
     
     public class InstallFeatureTestUtil extends InstallFeatureUtil {
-        public InstallFeatureTestUtil(File installDirectory, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVersion, List<String> additionalJsons)  throws PluginScenarioException, PluginExecutionException {
-            super(installDirectory, from, to, pluginListedEsas, propertiesList, openLibertyVersion, null, additionalJsons);
+        public InstallFeatureTestUtil(File installDirectory, File buildDirectory, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVersion, List<String> additionalJsons)  throws PluginScenarioException, PluginExecutionException {
+            super(installDirectory, buildDirectory, from, to, pluginListedEsas, propertiesList, openLibertyVersion, null, additionalJsons);
         }
 
         @Override
@@ -99,15 +102,15 @@ public class BaseInstallFeatureUtilTest {
     }
     
     public InstallFeatureUtil getNewInstallFeatureUtil() throws PluginExecutionException, PluginScenarioException {
-        return getNewInstallFeatureUtil(installDir, null, null, new HashSet<String>());
+        return getNewInstallFeatureUtil(installDir, buildDir, null, null, new HashSet<String>());
     }
 
-    public InstallFeatureUtil getNewInstallFeatureUtil(File installDirectory, String from, String to, Set<String> pluginListedEsas) throws PluginExecutionException, PluginScenarioException {
+    public InstallFeatureUtil getNewInstallFeatureUtil(File installDirectory, File buildDirectory, String from, String to, Set<String> pluginListedEsas) throws PluginExecutionException, PluginScenarioException {
         List<ProductProperties> propertiesList = InstallFeatureUtil.loadProperties(installDirectory);
         String openLibertyVersion = InstallFeatureUtil.getOpenLibertyVersion(propertiesList);
         List<String> additionalJsons = new ArrayList<String>();
 
-        return new InstallFeatureTestUtil(installDirectory, from, to, pluginListedEsas, propertiesList, openLibertyVersion, additionalJsons);
+        return new InstallFeatureTestUtil(installDirectory, buildDirectory, from, to, pluginListedEsas, propertiesList, openLibertyVersion, additionalJsons);
     }
     
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
@@ -47,7 +47,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         File wlProps = new File(installDir, "lib/versions/WebSphereApplicationServer.properties");
         assertTrue(olProps.delete());
         assertTrue(wlProps.delete());
-        getNewInstallFeatureUtil(installDir, null, null, new HashSet<String>());
+        getNewInstallFeatureUtil(installDir, buildDir, null, null, new HashSet<String>());
     }
     
     /**
@@ -57,7 +57,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
     public void testConstructorNoInstallMap() throws Exception {
         File installMap = new File(installDir, "lib/com.ibm.ws.install.map_1.0.21.jar");
         assertTrue(installMap.delete());
-        getNewInstallFeatureUtil(installDir, null, null, new HashSet<String>());
+        getNewInstallFeatureUtil(installDir, buildDir, null, null, new HashSet<String>());
     }
     
     /**
@@ -67,7 +67,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
     public void testConstructorNoOpenLibertyProperties() throws Exception {
         File olProps = new File(installDir, "lib/versions/openliberty.properties");
         assertTrue(olProps.delete());
-        getNewInstallFeatureUtil(installDir, null, null, new HashSet<String>());
+        getNewInstallFeatureUtil(installDir, buildDir, null, null, new HashSet<String>());
     }
     
     /**
@@ -79,12 +79,12 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         assertTrue(olProps.delete());
         File installMap = new File(installDir, "lib/com.ibm.ws.install.map_1.0.21.jar");
         assertTrue(installMap.delete());
-        getNewInstallFeatureUtil(installDir, null, null, new HashSet<String>());
+        getNewInstallFeatureUtil(installDir, buildDir, null, null, new HashSet<String>());
     }
         
     @Test
     public void testConstructorTo() throws Exception {
-        InstallFeatureUtil util = getNewInstallFeatureUtil(installDir, null, "myextension", new HashSet<String>());
+        InstallFeatureUtil util = getNewInstallFeatureUtil(installDir, buildDir, null, "myextension", new HashSet<String>());
         assertNotNull(util);
     }
     
@@ -93,7 +93,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
      */
     @Test(expected = PluginScenarioException.class)
     public void testConstructorFrom() throws Exception {
-        getNewInstallFeatureUtil(installDir, installDir.getAbsolutePath(), null, new HashSet<String>());
+        getNewInstallFeatureUtil(installDir, buildDir, installDir.getAbsolutePath(), null, new HashSet<String>());
     }
     
     /**
@@ -103,7 +103,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
     public void testConstructorEsas() throws Exception {
         Set<String> esas = new HashSet<String>();
         esas.add("abc.esa");
-        getNewInstallFeatureUtil(installDir, null, null, esas);
+        getNewInstallFeatureUtil(installDir, buildDir, null, null, esas);
     }
     
     /**
@@ -193,7 +193,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         List<ProductProperties> propertiesList = InstallFeatureUtil.loadProperties(installDir);
         String openLibertyVersion = InstallFeatureUtil.getOpenLibertyVersion(propertiesList);
         List<String> additionalJsons = new ArrayList<String>();
-        InstallFeatureUtil util = new InstallFeatureTestUtil(installDir, null, null, new HashSet<String>(), propertiesList, openLibertyVersion, additionalJsons) {
+        InstallFeatureUtil util = new InstallFeatureTestUtil(installDir, buildDir, null, null, new HashSet<String>(), propertiesList, openLibertyVersion, additionalJsons) {
             @Override
             public File downloadArtifact(String groupId, String artifactId, String type, String version)
                     throws PluginExecutionException {


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/liberty-language-server/issues/101.

Deleting the `.libertyls` directory (which contains generated schema files from Liberty Tools) when features are installed since the previously generated schema is no longer correct.

Had to pass in the build directory since that is where the `.libertyls` directory would be located. Maven and Gradle PRs are coming to reflect this change.