### PR TITLE
[#404] fix scope for maven-artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+
+        <dependency.maven-artifact.version>3.6.3</dependency.maven-artifact.version>
     </properties>
 
     <dependencies>
@@ -63,7 +65,8 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.6.3</version>
+            <version>${dependency.maven-artifact.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
* extract version into property to be consumed by ci.maven
* Scope is prerequisite for https://github.com/OpenLiberty/ci.maven/issues/1691
* extraction is sensible for using the same version in ci.maven.