### PR TITLE
Fix container builds logging info as error on Linux

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1386,7 +1386,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         Thread logCopyErrorThread = new Thread(new Runnable() {
             @Override
             public void run() {
-                firstErrorLine.append(copyStreamToBuildLog(startingProcess.getErrorStream(), false));
+                if (OSUtil.isLinux() && !isDocker) {
+                    firstErrorLine.append(copyStreamToBuildLog(startingProcess.getErrorStream(), true));
+                } else {
+                    firstErrorLine.append(copyStreamToBuildLog(startingProcess.getErrorStream(), false));
+                }
             }
         });
         logCopyErrorThread.start();


### PR DESCRIPTION
Fixes Podman build logging showing up as an error level message.

Error messages:
![Screenshot 2023-10-05 at 12 35 54 PM](https://github.com/OpenLiberty/ci.common/assets/6548952/bb98aa49-27eb-465a-986f-f05f76c761fc)

Fixed info messages:
![Screenshot 2023-10-05 at 12 35 37 PM](https://github.com/OpenLiberty/ci.common/assets/6548952/a32f2c69-6104-407f-b2a2-82c8fa564f42)