### PR TITLE
Support directory as valid location to include in server configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,6 @@ jobs:
         cache: 'maven'
     - name: Install ci.ant
       run: |
-        ./mvnw -V clean install -f ci.ant -DskipTests
+        ./mvnw -V clean install -ntp -f ci.ant -DskipTests
     - name: Build and run tests
-      run: ./mvnw -V clean install
+      run: ./mvnw -V clean install -ntp

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -510,7 +510,7 @@ public class ServerConfigDocument {
                 try {
                     docs.add(parseDocument(p.toFile()));
                 } catch (Exception e) {
-                    log.warn("Unable to parse from file " + p.getFileName() + " in include directory: " + directory.getName());
+                    log.warn("Unable to parse from file " + p.getFileName() + " from specified include directory: " + directory.getPath());
                 }
             });
     }

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -442,7 +442,7 @@ public class ServerConfigDocument {
         } else if (loc.startsWith("file:")) {
             if (isValidURL(loc)) {
                 locFile = new File(loc);
-                // While Java URIs support directories, the Liberty include implementation does not support them yet.
+                // While URIs support directories, the Liberty include implementation does not support them yet.
                 doc = parseDocument(locFile);
                 docs.add(doc);
             }

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -369,7 +369,7 @@ public class ServerConfigDocument {
                     continue;
                 }
 
-                ArrayList<Document> inclDocs = getIncludeDoc(includeFileName);
+                ArrayList<Document> inclDocs = getIncludeDocs(includeFileName);
                 for (Document inclDoc : inclDocs) {
                     parseApplication(inclDoc, XPATH_SERVER_APPLICATION);
                     parseApplication(inclDoc, XPATH_SERVER_WEB_APPLICATION);
@@ -427,7 +427,7 @@ public class ServerConfigDocument {
         }
     }
 
-    private static ArrayList<Document> getIncludeDoc(String loc) throws IOException, SAXException {
+    private static ArrayList<Document> getIncludeDocs(String loc) throws IOException, SAXException {
         ArrayList<Document> docs = new ArrayList<Document>();
         Document doc = null;
         File locFile = null;
@@ -442,7 +442,9 @@ public class ServerConfigDocument {
         } else if (loc.startsWith("file:")) {
             if (isValidURL(loc)) {
                 locFile = new File(loc);
-                parseDocumentFromFile(locFile, docs);
+                // While Java URIs support directories, the Liberty include implementation does not support them yet.
+                doc = parseDocument(locFile);
+                docs.add(doc);
             }
         } else if (loc.startsWith("ftp:")) {
             // TODO handle ftp protocol
@@ -451,7 +453,7 @@ public class ServerConfigDocument {
 
             // check if absolute file
             if (locFile.isAbsolute()) {
-                parseDocumentFromFile(locFile, docs);
+                parseDocumentFromFileOrDirectory(locFile, docs);
             } else {
                 // check configDirectory first if exists
                 if (configDirectory != null && configDirectory.exists()) {
@@ -461,7 +463,7 @@ public class ServerConfigDocument {
                 if (locFile == null || !locFile.exists()) {
                     locFile = new File(getServerXML().getParentFile(), loc);
                 }
-                parseDocumentFromFile(locFile, docs);
+                parseDocumentFromFileOrDirectory(locFile, docs);
             }
         }
 
@@ -479,7 +481,7 @@ public class ServerConfigDocument {
      * @throws IOException
      * @throws SAXException
      */
-    private static void parseDocumentFromFile(File file, ArrayList<Document> docs) throws FileNotFoundException, IOException, SAXException {
+    private static void parseDocumentFromFileOrDirectory(File file, ArrayList<Document> docs) throws FileNotFoundException, IOException, SAXException {
         Document doc = null;
         if (file == null || !file.exists()) {
             log.warn("Unable to parse from file: " + file.getCanonicalPath());
@@ -617,7 +619,7 @@ public class ServerConfigDocument {
                     continue;
                 }
 
-                ArrayList<Document> inclDocs = getIncludeDoc(includeFileName);
+                ArrayList<Document> inclDocs = getIncludeDocs(includeFileName);
 
                 for (Document inclDoc : inclDocs) {
                     parseVariablesForBothValues(inclDoc);

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -466,13 +466,17 @@ public class ServerConfigDocument {
                 parseDocumentFromFile(locFile, docs);
             }
         }
+
+        if (docs.isEmpty()) {
+            log.warn("Did not parse any file(s) from include location: " + loc);
+        }
         return docs;
     }
 
     /**
-     * Parses file or directory for all xml documents.
-     * @param file
-     * @param docs
+     * Parses file or directory for all xml documents, and adds to ArrayList<Document>
+     * @param file - file or directory to parse documents from
+     * @param docs - ArrayList to store parsed Documents.
      * @throws FileNotFoundException
      * @throws IOException
      * @throws SAXException
@@ -480,7 +484,7 @@ public class ServerConfigDocument {
     private static void parseDocumentFromFile(File file, ArrayList<Document> docs) throws FileNotFoundException, IOException, SAXException {
         Document doc = null;
         if (file == null || !file.exists()) {
-            log.debug("Unable to parse from file: " + file.getCanonicalPath());
+            log.warn("Unable to parse from file: " + file.getCanonicalPath());
             return;
         }
         if (file.isFile()) {
@@ -493,9 +497,9 @@ public class ServerConfigDocument {
     }
 
     /**
-     * In a given directory, parse all direct children xml files in alphabetical order by filename.
-     * @param directory
-     * @param docs
+     * In a given directory, parse all direct children xml files in alphabetical order by filename, and adds to ArrayList<Document>
+     * @param directory - directory to parse documents from
+     * @param docs - ArrayList to store parsed Documents.
      * @throws IOException
      */
     private static void parseDocumentsInDirectory(File directory, ArrayList<Document> docs) throws IOException {
@@ -506,16 +510,22 @@ public class ServerConfigDocument {
                 try {
                     docs.add(parseDocument(p.toFile()));
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.warn("Unable to parse from file " + p.getFileName() + " in include directory: " + directory.getName());
                 }
             });
     }
 
+    /**
+     * Parse Document from XML file
+     * @param file - XML file to parse for Document
+     * @return
+     * @throws FileNotFoundException
+     * @throws IOException
+     * @throws SAXException
+     */
     private static Document parseDocument(File file) throws FileNotFoundException, IOException, SAXException {
         InputStream is = new FileInputStream(file.getCanonicalPath());
-        Document doc = parseDocument(is);
-        is.close();
-        return doc;
+        return parseDocument(is);
     }
 
     private static Document parseDocument(InputStream in) throws SAXException, IOException {
@@ -616,8 +626,6 @@ public class ServerConfigDocument {
                         parseVariablesForBothValues(inclDoc);
                         // handle nested include elements
                         parseIncludeVariables(inclDoc);
-                    } else {
-                        log.warn("Unable to parse include file "+includeFileName+". Skipping the included file during application location processing.");
                     }
                 }
             }

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -371,13 +371,11 @@ public class ServerConfigDocument {
 
                 ArrayList<Document> inclDocs = getIncludeDoc(includeFileName);
                 for (Document inclDoc : inclDocs) {
-                    if (inclDoc != null) {
-                        parseApplication(inclDoc, XPATH_SERVER_APPLICATION);
-                        parseApplication(inclDoc, XPATH_SERVER_WEB_APPLICATION);
-                        parseApplication(inclDoc, XPATH_SERVER_ENTERPRISE_APPLICATION);
-                        // handle nested include elements
-                        parseInclude(inclDoc);
-                    }
+                    parseApplication(inclDoc, XPATH_SERVER_APPLICATION);
+                    parseApplication(inclDoc, XPATH_SERVER_WEB_APPLICATION);
+                    parseApplication(inclDoc, XPATH_SERVER_ENTERPRISE_APPLICATION);
+                    // handle nested include elements
+                    parseInclude(inclDoc);
                 }
             }
         }
@@ -622,11 +620,9 @@ public class ServerConfigDocument {
                 ArrayList<Document> inclDocs = getIncludeDoc(includeFileName);
 
                 for (Document inclDoc : inclDocs) {
-                    if (inclDoc != null) {
-                        parseVariablesForBothValues(inclDoc);
-                        // handle nested include elements
-                        parseIncludeVariables(inclDoc);
-                    }
+                    parseVariablesForBothValues(inclDoc);
+                    // handle nested include elements
+                    parseIncludeVariables(inclDoc);
                 }
             }
         }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -483,7 +483,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                 String onConflict = node.getAttribute("onConflict");
                 Set<String> features = getServerXmlFeatures(null, serverDirectory, file, bootstrapProperties, updatedParsedXmls);
                 if (features != null && !features.isEmpty()) {
-                    info("Features were included for file "+ file.getCanonicalPath());
+                    info("Features were included for file "+ file.toString());
                 }
                 result = handleOnConflict(result, onConflict, features);
             }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -599,6 +599,7 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     @Test
     public void testIncludeDir() throws Exception {
         replaceIncludeDir("includeDir");
+        copy("includeDir");
 
         Set<String> expected = new HashSet<String>();
         expected.add("orig");
@@ -635,7 +636,7 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
 
     private void replaceIncludeDir(String includeDirName) throws Exception {
         File includeDir = new File(src, includeDirName);
-        replaceIncludeLocation(includeDir.getCanonicalPath());
+        replaceIncludeLocation(includeDir.getName());
     }
     
     /**

--- a/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigDocumentTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/ServerConfigDocumentTest.java
@@ -46,6 +46,8 @@ public class ServerConfigDocumentTest {
 		String compareAppLocation3 = "test-war-three.war";
 		 // this next one won't resolve because the var referenced in the include location uses a variable with a non-default value in server.xml
 		String compareAppLocation4 = "${project.artifactId.four}.ear"; 
+		String compareAppLocation5 = "test-war-five.war";
+		String compareAppLocation6 = "test-war-six.war";
 
 		Map<String, File> libertyDirectoryPropertyToFile = getLibertyDirectoryPropertyFiles(log, serverDirectory);
 
@@ -53,12 +55,14 @@ public class ServerConfigDocumentTest {
 
 		ServerConfigDocument scd = ServerConfigDocument.getInstance(log, serverXML, serverDirectory, null, null, null, true, libertyDirectoryPropertyToFile);
 		Set<String> locations = scd.getLocations();
-		assertTrue("Expected four app locations", locations.size() == 4);
+		assertTrue("Expected six app locations", locations.size() == 6);
 
 		boolean locOneFound = false;
 		boolean locTwoFound = false;
 		boolean locThreeFound = false;
 		boolean locFourFound = false;
+		boolean locFiveFound = false;
+		boolean locSixFound = false;
 
 		for (String loc : locations) {
 			if (loc.contains("-two")) {
@@ -70,6 +74,12 @@ public class ServerConfigDocumentTest {
 			} else if (loc.endsWith(".ear")) {
 				assertTrue("Unexpected app location found: "+loc, loc.equals(compareAppLocation4));
 				locFourFound = true;
+			} else if (loc.contains("-five")) {
+				assertTrue("Unexpected app location found: "+loc, loc.equals(compareAppLocation5));
+				locFiveFound = true;
+			} else if (loc.contains("-six")) {
+				assertTrue("Unexpected app location found: "+loc, loc.equals(compareAppLocation6));
+				locSixFound = true;
 			} else {
 				assertTrue("Unexpected app location found: "+loc, loc.equals(compareAppLocation1));
 				locOneFound = true;
@@ -80,6 +90,8 @@ public class ServerConfigDocumentTest {
 		assertTrue("App location two not found.", locTwoFound);
 		assertTrue("App location three not found.", locThreeFound);
 		assertTrue("App location four not found.", locFourFound);
+		assertTrue("App location five not found.", locFiveFound);
+		assertTrue("App location six not found.", locSixFound);
 
 	}
 

--- a/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/includeDir/anotherInclude.xml
+++ b/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/includeDir/anotherInclude.xml
@@ -1,0 +1,3 @@
+<server description="">
+    <variable name="project.artifactId.five" value="test-war-five"/>
+</server>

--- a/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/includeDir/yetAnotherInclude.xml
+++ b/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/includeDir/yetAnotherInclude.xml
@@ -1,0 +1,3 @@
+<server description="">
+    <variable name="project.artifactId.six" value="test-war-six"/>
+</server>

--- a/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/server.xml
+++ b/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/server.xml
@@ -17,4 +17,8 @@
     <include location="${includeLocationNonDefault}/firstInclude.xml"/>    
     <webApplication location="${project.artifactId.four}.ear"/>
 
+    <include location="${server.config.dir}/includeDir"/>
+    <webApplication location="${project.artifactId.five}.war"/>
+    <webApplication location="${project.artifactId.six}.war"/>
+
 </server>

--- a/src/test/resources/servers/includeDir/extraFeatures.xml
+++ b/src/test/resources/servers/includeDir/extraFeatures.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+	<featureManager>
+        <feature>extra</feature>
+    </featureManager>
+</server>

--- a/src/test/resources/servers/includeDir/extraFeatures2.xml
+++ b/src/test/resources/servers/includeDir/extraFeatures2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+	<featureManager>
+        <feature>extra2</feature>
+    </featureManager>
+</server>

--- a/src/test/resources/servers/includeDir/extraFeatures4.xml
+++ b/src/test/resources/servers/includeDir/extraFeatures4.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+	<featureManager>
+        <feature>extra4</feature>
+    </featureManager>
+</server>

--- a/src/test/resources/servers/server_dir_ignore.xml
+++ b/src/test/resources/servers/server_dir_ignore.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <featureManager>
+        <feature>orig</feature>
+    </featureManager>
+    <include location="includeDir" onConflict="IGNORE"/>
+</server>

--- a/src/test/resources/servers/server_dir_replace.xml
+++ b/src/test/resources/servers/server_dir_replace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <featureManager>
+        <feature>orig</feature>
+    </featureManager>
+    <include location="includeDir" onConflict="REPLACE"/>
+</server>


### PR DESCRIPTION
Fixes OpenLiberty/ci.maven#1720

When a directory is specified in `<include>`, parse all direct children xml files alphabetically.
Added tests for directory include support.