### PR TITLE
Modify behavior for include directory to match Liberty

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -473,15 +473,16 @@ public class ServerConfigDocument {
     /**
      * Parses file or directory for all xml documents, and adds to ArrayList<Document>
      * @param f - file or directory to parse documents from
-     * @param isLibertyDirectory - indicates if directory. Liberty bases this off of the presence of trailing File.separator
+     * @param locationString - String representation of filepath for f
      * @param docs - ArrayList to store parsed Documents.
      * @throws FileNotFoundException
      * @throws IOException
      * @throws SAXException
      */
-    private static void parseDocumentFromFileOrDirectory(File f, String loc, ArrayList<Document> docs) throws FileNotFoundException, IOException, SAXException {
+    private static void parseDocumentFromFileOrDirectory(File f, String locationString, ArrayList<Document> docs) throws FileNotFoundException, IOException, SAXException {
         Document doc = null;
-        boolean isLibertyDirectory = loc.endsWith("/"); // Liberty uses this to determine if directory
+        // Earlier call to VariableUtility.resolveVariables() already converts all \ to /
+        boolean isLibertyDirectory = locationString.endsWith("/");  // Liberty uses this to determine if directory. 
 
         if (f == null || !f.exists()) {
             log.warn("Unable to parse from file: " + f.getCanonicalPath());
@@ -489,17 +490,16 @@ public class ServerConfigDocument {
         }
         // If file mismatches Liberty definition of directory
         if (f.isFile() && isLibertyDirectory) {
-            log.error("Path specified a directory, but resource exists as a file (path=" + loc + ")");
+            log.error("Path specified a directory, but resource exists as a file (path=" + locationString + ")");
             return;
         } else if (f.isDirectory() && !isLibertyDirectory) {
-            log.error("Path specified a file, but resource exists as a directory (path=" + loc + ")");
+            log.error("Path specified a file, but resource exists as a directory (path=" + locationString + ")");
             return;
         }
 
         if (f.isDirectory()) {
             parseDocumentsInDirectory(f, docs);
-        }
-        if (f.isFile()) {
+        } else {
             doc = parseDocument(f);
             docs.add(doc);
         }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -290,7 +290,9 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
      * @param msg
      * @return
      */
-    public abstract boolean containsErrorMessage(String msg);
+    public boolean containsErrorMessage(String msg) {
+        return false;
+    }
 
     /**
      * Returns whether debug is enabled by the current logger

--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -286,6 +286,8 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
 
     /**
      * Check if any of the logged errors contain the given string.
+     * Default does nothing - 
+     * Override this method to use as needed.
      * 
      * @param msg
      * @return

--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -285,6 +285,14 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
     public abstract void error(String msg, Throwable e);
 
     /**
+     * Check if any of the logged errors contain the given string.
+     * 
+     * @param msg
+     * @return
+     */
+    public abstract boolean containsErrorMessage(String msg);
+
+    /**
      * Returns whether debug is enabled by the current logger
      * 
      * @return whether debug is enabled

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -423,7 +423,6 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         Set<String> result = origResult;
         // Need to handle more variable substitution for include location.
         String nodeValue = node.getAttribute("location");
-        // NOTE: resolveVariables converts Windows \ into /
         String includeFileName = VariableUtility.resolveVariables(this, nodeValue, null, bootstrapProperties, new Properties(), getLibertyDirectoryPropertyFiles());
 
         if (includeFileName == null || includeFileName.trim().isEmpty()) {
@@ -476,7 +475,8 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
     }
 
     private ArrayList<File> parseIncludeFileOrDirectory(String includeFileName, File includeFile) {
-        boolean isLibertyDirectory = includeFileName.endsWith("/"); // Note, resolveVariables converts Windows File.separator to use forward slash
+        // Earlier call to VariableUtility.resolveVariables() already converts all \ to /
+        boolean isLibertyDirectory = includeFileName.endsWith("/"); // Liberty uses this to determine if directory. 
         ArrayList<File> includeFiles = new ArrayList<File>();
         if (includeFile.isFile() && isLibertyDirectory) {
             error("Path specified a directory, but resource exists as a file (path=" + includeFileName + ")");

--- a/src/main/java/io/openliberty/tools/common/plugins/util/VariableUtility.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/VariableUtility.java
@@ -28,10 +28,12 @@ public class VariableUtility {
     private static final String VARIABLE_NAME_PATTERN = "\\$\\{(.*?)\\}";
     private static final Pattern varNamePattern = Pattern.compile(VARIABLE_NAME_PATTERN);
 
-    /*
+    /**
      * Attempts to resolve all variables in the passed in nodeValue. Variable value/defaultValue can reference other variables.
      * This method is called recursively to resolve the variables. The variableChain collection keeps track of the variable references
      * in a resolution chain in order to prevent an infinite loop. The variableChain collection should be passed as null on the initial call.
+     * 
+     * NOTE: This method also replaces all back slashes with forward slashes
      */
     public static String resolveVariables(CommonLoggerI log, String nodeValue, Collection<String> variableChain, 
                                             Properties props, Properties defaultProps, Map<String, File> libDirPropFiles) {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/BaseInstallFeatureUtilTest.java
@@ -41,6 +41,8 @@ public class BaseInstallFeatureUtilTest {
     public File installDir;
     public File buildDir;
     public String verify = "enforce";
+
+    private ArrayList<String> errorMessages = new ArrayList<String>();
     
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
@@ -87,11 +89,22 @@ public class BaseInstallFeatureUtilTest {
         @Override
         public void error(String msg) {
             // not needed for tests
+            errorMessages.add(msg);
         }
 
         @Override
         public void error(String msg, Throwable e) {
             // not needed for tests
+        }
+
+        @Override
+        public boolean containsErrorMessage(String msg) {
+            for (String error : errorMessages) {
+                if (error.contains(msg)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -598,7 +598,8 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
      */
     @Test
     public void testIncludeDir() throws Exception {
-        replaceIncludeDir("includeDir");
+        // Note: Both the product code and test code end up converting Windows \ into /
+        replaceIncludeLocation("includeDir/"); 
         copy("includeDir");
 
         Set<String> expected = new HashSet<String>();
@@ -632,11 +633,6 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("orig");
 
         verifyServerFeatures(expected);
-    }
-
-    private void replaceIncludeDir(String includeDirName) throws Exception {
-        File includeDir = new File(src, includeDirName);
-        replaceIncludeLocation(includeDir.getName());
     }
     
     /**

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -625,6 +625,7 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("orig");
 
         verifyServerFeatures(expected);
+        util.containsErrorMessage("Path specified a file, but resource exists as a directory (path=includeDir)");
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.common.plugins.util;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -625,7 +626,7 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("orig");
 
         verifyServerFeatures(expected);
-        util.containsErrorMessage("Path specified a file, but resource exists as a directory (path=includeDir)");
+        assertTrue(util.containsErrorMessage("Path specified a file, but resource exists as a directory (path=includeDir)"));
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -593,7 +593,7 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     }
 
     /**
-     * Tests server.xml with include dir
+     * Tests server.xml with include dir (must end with trailing slash)
      * @throws Exception
      */
     @Test
@@ -607,6 +607,22 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("extra");
         expected.add("extra2");
         expected.add("extra4");
+
+        verifyServerFeatures(expected);
+    }
+
+    /**
+     * Tests include directory without the trailing slash.
+     * Liberty treats this as a file, which conflicts with it being a dir, and throws an error.
+     * @throws Exception
+     */
+    @Test
+    public void testInvalidIncludeDir() throws Exception {
+        replaceIncludeLocation("includeDir"); 
+        copy("includeDir");
+
+        Set<String> expected = new HashSet<String>();
+        expected.add("orig");
 
         verifyServerFeatures(expected);
     }

--- a/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/server.xml
+++ b/src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer/server.xml
@@ -17,7 +17,7 @@
     <include location="${includeLocationNonDefault}/firstInclude.xml"/>    
     <webApplication location="${project.artifactId.four}.ear"/>
 
-    <include location="${server.config.dir}/includeDir"/>
+    <include location="${server.config.dir}/includeDir/"/>
     <webApplication location="${project.artifactId.five}.war"/>
     <webApplication location="${project.artifactId.six}.war"/>
 

--- a/src/test/resources/servers/server_dir_ignore.xml
+++ b/src/test/resources/servers/server_dir_ignore.xml
@@ -3,5 +3,5 @@
     <featureManager>
         <feature>orig</feature>
     </featureManager>
-    <include location="includeDir" onConflict="IGNORE"/>
+    <include location="includeDir/" onConflict="IGNORE"/>
 </server>

--- a/src/test/resources/servers/server_dir_replace.xml
+++ b/src/test/resources/servers/server_dir_replace.xml
@@ -3,5 +3,5 @@
     <featureManager>
         <feature>orig</feature>
     </featureManager>
-    <include location="includeDir" onConflict="REPLACE"/>
+    <include location="includeDir/" onConflict="REPLACE"/>
 </server>


### PR DESCRIPTION
Match Liberty behavior where <include> directory has to end in File.separator
> Note: Both Liberty and our test code convert Windows `\` into `/`, so all the logic uses `/`

Note implemented behavior in https://github.com/OpenLiberty/ci.common/pull/426#discussion_r1373606247