### PR TITLE
Correctly sort dir files alphabetically to match Liberty behavior

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -22,15 +22,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 import java.util.Map;
 import java.util.Properties;
 
@@ -43,6 +39,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.io.comparator.NameFileComparator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -384,41 +381,33 @@ public class ServerConfigDocument {
     private static void parseConfigDropinsDir() throws XPathExpressionException, IOException, SAXException {
         File configDropins = getConfigDropinsDir();
 
-        if (configDropins != null && configDropins.exists()) {
-            File overrides = new File(configDropins, "overrides");
-            if (overrides.exists()) {
-                parseDropinsFiles(overrides.listFiles());
-            }
+        if (configDropins == null || !configDropins.exists()) {
+            return;
+        }
 
-            File defaults = new File(configDropins, "defaults");
-            if (defaults.exists()) {
-                parseDropinsFiles(defaults.listFiles());
-            }
+        File overrides = new File(configDropins, "overrides");
+        if (overrides.exists()) {
+            parseDropinsFiles(overrides.listFiles());
+        }
+
+        File defaults = new File(configDropins, "defaults");
+        if (defaults.exists()) {
+            parseDropinsFiles(defaults.listFiles());
         }
     }
 
     private static void parseDropinsFiles(File[] files) throws XPathExpressionException, IOException, SAXException {
-        for (int i = 0; i < files.length; i++) {
-            if (files[i].isFile()) {
-                parseDropinsFile(files[i]);
+        Arrays.sort(files, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
+        for (File file : files) {
+            if (file.isFile()) {
+                parseDropinsFile(file);
             }
-        }
-    }
-
-    private static Document parseDropinsXMLFile(File file) throws FileNotFoundException, IOException {
-        try (FileInputStream is = new FileInputStream(file)) {
-            return parseDocument(is);
-        } catch (SAXException ex) {
-            // If the file was not valid XML, assume it was some other non XML
-            // file in dropins.
-            log.info("Skipping parsing " + file.getAbsolutePath() + " because it was not recognized as XML.");
-            return null;
         }
     }
 
     private static void parseDropinsFile(File file) throws IOException, XPathExpressionException, SAXException {
         // get input XML Document
-        Document doc = parseDropinsXMLFile(file);
+        Document doc = parseDocument(file);
         if (doc != null) {
             parseApplication(doc, XPATH_SERVER_APPLICATION);
             parseApplication(doc, XPATH_SERVER_WEB_APPLICATION);
@@ -511,17 +500,19 @@ public class ServerConfigDocument {
      * @param docs - ArrayList to store parsed Documents.
      * @throws IOException
      */
-    private static void parseDocumentsInDirectory(File directory, ArrayList<Document> docs) throws IOException {
-        DirectoryStream<Path> dstream = Files.newDirectoryStream(directory.toPath(), "*.xml");
-        StreamSupport.stream(dstream.spliterator(), false)
-            .sorted(Comparator.comparing(Path::toString))
-            .forEach(p -> { 
-                try {
-                    docs.add(parseDocument(p.toFile()));
-                } catch (Exception e) {
-                    log.warn("Unable to parse from file " + p.getFileName() + " from specified include directory: " + directory.getPath());
-                }
-            });
+    private static void parseDocumentsInDirectory(File directory, ArrayList<Document> docs) {
+        // OpenLiberty reference code for behavior, parseInclude() method
+        // https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java#L409C8-L409C8
+        // uses Collections.sort on filenames which is case-sensitive (all uppercase comes before lowercase)
+        File[] files = directory.listFiles();
+        Arrays.sort(files, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
+        for (File file : files) {
+            try {
+                docs.add(parseDocument(file));
+            } catch (Exception e) {
+                log.warn("Unable to parse from file " + file.getPath() + " from specified include directory: " + directory.getPath());
+            }
+        }
     }
 
     /**
@@ -532,9 +523,15 @@ public class ServerConfigDocument {
      * @throws IOException
      * @throws SAXException
      */
-    private static Document parseDocument(File file) throws FileNotFoundException, IOException, SAXException {
-        InputStream is = new FileInputStream(file.getCanonicalPath());
-        return parseDocument(is);
+    private static Document parseDocument(File file) throws FileNotFoundException, IOException {
+        try (FileInputStream is = new FileInputStream(file)) {
+            return parseDocument(is);
+        } catch (SAXException ex) {
+            // If the file was not valid XML, assume it was some other non XML
+            // file in dropins.
+            log.info("Skipping parsing " + file.getAbsolutePath() + " because it was not recognized as XML.");
+            return null;
+        }
     }
 
     private static Document parseDocument(InputStream in) throws SAXException, IOException {
@@ -657,18 +654,20 @@ public class ServerConfigDocument {
     private static void parseConfigDropinsDirVariables(String inDir)
             throws XPathExpressionException, SAXException, IOException {
         File configDropins = getConfigDropinsDir();
+        if (configDropins == null || !configDropins.exists()) {
+            return;
+        }
 
-        if (configDropins != null && configDropins.exists()) {
-            File dir = new File(configDropins, inDir);
+        File dir = new File(configDropins, inDir);
+        if (!dir.exists()) {
+            return;
+        }
 
-            if (dir.exists()) {
-                File[] cfgFiles = dir.listFiles();
-
-                for (int i = 0; i < cfgFiles.length; i++) {
-                    if (cfgFiles[i].isFile()) {
-                        parseDropinsFilesVariables(cfgFiles[i]);
-                    }
-                }
+        File[] cfgFiles = dir.listFiles();
+        Arrays.sort(cfgFiles, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
+        for (File file : cfgFiles) {
+            if (file.isFile()) {
+                parseDropinsFilesVariables(file);
             }
         }
     }
@@ -676,7 +675,7 @@ public class ServerConfigDocument {
     private static void parseDropinsFilesVariables(File file)
             throws SAXException, IOException, XPathExpressionException {
         // get input XML Document
-        Document doc = parseDropinsXMLFile(file);
+        Document doc = parseDocument(file);
         if (doc != null) {
             parseVariablesForBothValues(doc);
             parseIncludeVariables(doc);

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -200,7 +200,7 @@ public class ServerConfigDocument {
             props = new Properties();
             defaultProps = new Properties();
 
-            Document doc = parseDocument(new FileInputStream(serverXMLFile));
+            Document doc = parseDocument(serverXMLFile);
 
             // Server variable precedence in ascending order if defined in
             // multiple locations.
@@ -424,8 +424,7 @@ public class ServerConfigDocument {
         if (loc.startsWith("http:") || loc.startsWith("https:")) {
             if (isValidURL(loc)) {
                 URL url = new URL(loc);
-                URLConnection connection = url.openConnection();
-                doc = parseDocument(connection.getInputStream());
+                doc = parseDocument(url);
                 docs.add(doc);
             }
         } else if (loc.startsWith("file:")) {
@@ -530,6 +529,13 @@ public class ServerConfigDocument {
             // file in dropins.
             log.info("Skipping parsing " + file.getAbsolutePath() + " because it was not recognized as XML.");
             return null;
+        }
+    }
+
+    private static Document parseDocument(URL url) throws IOException, SAXException {
+        URLConnection connection = url.openConnection();
+        try (InputStream is = connection.getInputStream()) {
+            return parseDocument(is);
         }
     }
 

--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -501,9 +501,8 @@ public class ServerConfigDocument {
      * @throws IOException
      */
     private static void parseDocumentsInDirectory(File directory, ArrayList<Document> docs) {
-        // OpenLiberty reference code for behavior, parseInclude() method
-        // https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java#L409C8-L409C8
-        // uses Collections.sort on filenames which is case-sensitive (all uppercase comes before lowercase)
+        // OpenLiberty reference code for behavior: https://github.com/OpenLiberty/open-liberty
+        // ServerXMLConfiguration.java:parseDirectoryFiles() and XMLConfigParser.java:parseInclude()
         File[] files = directory.listFiles();
         Arrays.sort(files, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
         for (File file : files) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -246,7 +246,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         File[] configDropinsXmls = configDropinsFolder.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
-                return name.endsWith(".xml") && (dropinsFilesToIgnore == null || !dropinsFilesToIgnore.contains(name));
+                return name.toLowerCase().endsWith(".xml") && (dropinsFilesToIgnore == null || !dropinsFilesToIgnore.contains(name));
             }
         });
         if (configDropinsXmls == null || configDropinsXmls.length == 0) {
@@ -484,7 +484,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         }
 
         if (includeFile.isDirectory()) {
-            File[] files = includeFile.listFiles();
+            File[] files = includeFile.listFiles((dir, name) -> name.toLowerCase().endsWith(".xml"));
             Arrays.sort(files, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
             for (File file : files) {
                 includeFiles.add(file);

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -24,9 +24,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -41,7 +38,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 import java.util.logging.Level;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -49,6 +45,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.comparator.NameFileComparator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -487,18 +484,10 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         }
 
         if (includeFile.isDirectory()) {
-            try (DirectoryStream<Path> dstream = Files.newDirectoryStream(includeFile.toPath(), "*.xml")) {
-                StreamSupport.stream(dstream.spliterator(), false)
-                    .sorted(Comparator.comparing(Path::toString))
-                    .forEach(p -> { 
-                        try {
-                            includeFiles.add(p.toFile());
-                        } catch (Exception e) {
-                            debug("Failed to resolve file from path: " + p);
-                        }
-                    });
-            } catch (IOException e) {
-                debug("Unable to open include directory: " + includeFileName);
+            File[] files = includeFile.listFiles();
+            Arrays.sort(files, NameFileComparator.NAME_INSENSITIVE_COMPARATOR);
+            for (File file : files) {
+                includeFiles.add(file);
             }
         } else {
             includeFiles.add(includeFile);


### PR DESCRIPTION
- Use case-insensitive sort for dir files to match Liberty behavior.
- Fix configDropins processing to sort alphabetically
- Simplified and refactored some code.

Current 23.0.0.10 release has a bug where it uses case-sensitive sort for `<include>` dirs.
Fix in open-liberty went in recently, and will be in the 23.0.0.12 release