### PR TITLE
Change containerEngine to containerType

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -5710,7 +5710,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             metadataWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(metaFileWriter) ;
             metadataWriter.writeStartDocument();
             metadataWriter.writeStartElement("devcModeMetaData");
-            writeElement(metadataWriter, "containerEngine", isDocker ? DEVC_CONTAINER_DOCKER : DEVC_CONTAINER_PODMAN);
+            writeElement(metadataWriter, "containerType", isDocker ? DEVC_CONTAINER_DOCKER : DEVC_CONTAINER_PODMAN);
             writeElement(metadataWriter, "containerName", containerName != null ? containerName : DEVMODE_CONTAINER_BASE_NAME);
             writeElement(metadataWriter, "imageName", imageName);
             if (containerfile != null) {

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilTest.java
@@ -540,7 +540,7 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertTrue(content.contains("<containerName>liberty-dev</containerName"));
         assertTrue(content.contains("<containerAlive>true</containerAlive>"));
         assertTrue(content.contains("<containerBuildTimeout>600</containerBuildTimeout>"));
-        assertTrue(content.contains("<containerEngine>docker</containerEngine>"));
+        assertTrue(content.contains("<containerType>docker</containerType>"));
         assertTrue(content.contains("<containerRunOpts></containerRunOpts>"));
         assertTrue(content.contains("<imageName></imageName>"));
 
@@ -549,7 +549,7 @@ public class DevUtilTest extends BaseDevUtilTest {
         assertTrue(content.contains("<containerName>liberty-dev</containerName"));
         assertTrue(content.contains("<containerAlive>false</containerAlive>"));
         assertTrue(content.contains("<containerBuildTimeout>600</containerBuildTimeout>"));
-        assertTrue(content.contains("<containerEngine>docker</containerEngine>"));
+        assertTrue(content.contains("<containerType>docker</containerType>"));
         assertTrue(content.contains("<containerRunOpts></containerRunOpts>"));
         assertTrue(content.contains("<imageName></imageName>"));
     }


### PR DESCRIPTION
Fix related to https://github.com/OpenLiberty/liberty-language-server/issues/253. The Liberty Config Language Server expected `containerType` instead of `containerEngine` for the xml element name indicating whether docker or podman was being used. Since that is the only consumer of this information so far, decided to make the change here since we plan to do a release soon.