### PR TITLE
Trim user id before adding to docker run command

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -1837,7 +1837,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 String id = runCmd("id -u");
                 if (id != null) {
                     commandElements.add("--user");
-                    commandElements.add(id);
+                    commandElements.add(id.trim());
                 }
             } catch (IOException e) {
                 // can't get user id. runCmd has printed an error message.


### PR DESCRIPTION
For internally reported issue with running devc on LMP 3.10.1. The same scenario worked on LMP 3.10. The error reported was:

```
[ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.10.1:devc (default-cli) on project guide-testcontainers: Error starting the server in dev mode.: An error occurred while running the container: docker: Error response from daemon: unable to find user 0 : no matching entries in passwd file. RC=125 -> [Help 1]
```

There seems to be a trailing space for the `--user 0 ` on the `docker run` command. The changes made in [PR](https://github.com/OpenLiberty/ci.common/pull/441) causes this space to be preserved, whereas it would have been trimmed previously.