### PR TITLE
Start parsing platforms, along with features in featureManager node

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -81,6 +81,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import com.sun.nio.file.SensitivityWatchEventModifier;
 
 import io.openliberty.tools.ant.ServerTask;
+import io.openliberty.tools.common.plugins.util.ServerFeatureUtil.FeaturesPlatforms;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -5749,14 +5750,14 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
         if (generateFeatures) {
             // generateFeatures scenario: check if a generated feature has been manually added to other config files
-            generatedFeatureSet = servUtil.getServerXmlFeatures(null, serverDirectory,
-            generatedFeaturesFile, null, null);
+            generatedFeatureSet = servUtil.getServerXmlFeatures(new FeaturesPlatforms(), serverDirectory,
+            generatedFeaturesFile, null, null).getFeatures();
             Set<String> generatedFiles = new HashSet<String>();
             generatedFiles.add(generatedFeaturesFile.getName());
             // if serverXmlFile is null, getServerFeatures will use the default server.xml
             // in the configDirectory
             featuresExcludingGenerated = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                    new HashMap<String, File>(), generatedFiles);
+                    new HashMap<String, File>(), generatedFiles).getFeatures();
             if (featuresExcludingGenerated != null && generatedFeatureSet != null
                     && !Collections.disjoint(featuresExcludingGenerated, generatedFeatureSet)) {
                 // indicates a generated feature has been manually added to other config files
@@ -5764,7 +5765,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             }
         } else {
             featuresExcludingGenerated = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                    new HashMap<String, File>(), null);
+                    new HashMap<String, File>(), null).getFeatures();
         }
         
         // compare current feature list to existing feature list
@@ -5790,10 +5791,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     // returns the features specified in the generated-features.xml file
     private Set<String> getGeneratedFeatures() {
         ServerFeatureUtil servUtil = getServerFeatureUtilObj();
-        Set<String> genFeatSet = new HashSet<String>();
-        servUtil.getServerXmlFeatures(genFeatSet, configDirectory,
-                generatedFeaturesFile, null, null);
-        return genFeatSet;
+        return servUtil.getServerXmlFeatures(new FeaturesPlatforms(), configDirectory,
+                generatedFeaturesFile, null, null).getFeatures();
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -5750,22 +5750,28 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
         if (generateFeatures) {
             // generateFeatures scenario: check if a generated feature has been manually added to other config files
-            generatedFeatureSet = servUtil.getServerXmlFeatures(new FeaturesPlatforms(), serverDirectory,
-            generatedFeaturesFile, null, null).getFeatures();
+        	FeaturesPlatforms fp = servUtil.getServerXmlFeatures(new FeaturesPlatforms(), serverDirectory,
+                    generatedFeaturesFile, null, null);
+        	if (fp != null)
+        		generatedFeatureSet = fp.getFeatures();
             Set<String> generatedFiles = new HashSet<String>();
             generatedFiles.add(generatedFeaturesFile.getName());
             // if serverXmlFile is null, getServerFeatures will use the default server.xml
             // in the configDirectory
-            featuresExcludingGenerated = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                    new HashMap<String, File>(), generatedFiles).getFeatures();
+            fp = servUtil.getServerFeatures(configDirectory, serverXmlFile,
+                    new HashMap<String, File>(), generatedFiles);
+            if (fp != null)
+            	featuresExcludingGenerated = fp.getFeatures();
             if (featuresExcludingGenerated != null && generatedFeatureSet != null
                     && !Collections.disjoint(featuresExcludingGenerated, generatedFeatureSet)) {
                 // indicates a generated feature has been manually added to other config files
                 return true;
             }
         } else {
-            featuresExcludingGenerated = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                    new HashMap<String, File>(), null).getFeatures();
+        	FeaturesPlatforms fp = servUtil.getServerFeatures(configDirectory, serverXmlFile,
+                    new HashMap<String, File>(), null);
+        	if (fp != null)
+        		featuresExcludingGenerated = fp.getFeatures();
         }
         
         // compare current feature list to existing feature list
@@ -5791,8 +5797,9 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     // returns the features specified in the generated-features.xml file
     private Set<String> getGeneratedFeatures() {
         ServerFeatureUtil servUtil = getServerFeatureUtilObj();
-        return servUtil.getServerXmlFeatures(new FeaturesPlatforms(), configDirectory,
-                generatedFeaturesFile, null, null).getFeatures();
+        FeaturesPlatforms fp = servUtil.getServerXmlFeatures(new FeaturesPlatforms(), configDirectory,
+                generatedFeaturesFile, null, null);
+        return fp!=null ? fp.getFeatures() : new HashSet<String>(); 
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -661,7 +661,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
      *                                  installed
      */
     @SuppressWarnings("unchecked")
-    public void installFeatures(boolean isAcceptLicense, List<String> featuresList)
+    public void installFeatures(boolean isAcceptLicense, List<String> featuresList, List<String> platformsList)
             throws PluginExecutionException {
     	
     	Map<String, String> featureToExtMap = new HashMap<String, String>();
@@ -727,7 +727,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
 	        mapBasedInstallKernel = createMapBasedInstallKernelInstance(bundle, installDirectory);
 	    
 	    
-	        Collection<?> resolvedFeatures = resolveFeatures(featuresToInstall, jsonRepos, acceptLicenseMapValue, pluginListedEsas);
+	        Collection<?> resolvedFeatures = resolveFeatures(featuresToInstall, platformsList,jsonRepos, acceptLicenseMapValue, pluginListedEsas);
 	        if(resolvedFeatures == null || resolvedFeatures.isEmpty()) {
 		        return;
 	        }
@@ -816,13 +816,14 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
      * @return Collection of resolved features
      * @throws PluginExecutionException
      */
-    private Collection<?> resolveFeatures(List<String> featuresToInstall, List<File> jsonRepos,
+    private Collection<?> resolveFeatures(List<String> featuresToInstall,List<String> platforms, List<File> jsonRepos,
 	    boolean acceptLicenseMapValue, Set<String> localESA) throws PluginExecutionException {
 	info("Resolving features... " );
 	
 	mapBasedInstallKernel.put("install.local.esa", true);
 	mapBasedInstallKernel.put("single.json.file", jsonRepos);
 	mapBasedInstallKernel.put("features.to.resolve", featuresToInstall);
+	mapBasedInstallKernel.put("platforms", platforms);
 	mapBasedInstallKernel.put("license.accept", acceptLicenseMapValue);
 	mapBasedInstallKernel.put("is.install.server.feature", true);
 	if(!localESA.isEmpty()) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -393,7 +393,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                         Element child = (Element) nodes.item(i);
                         if ("featureManager".equals(child.getNodeName())) {
                             if (result == null) {
-                                result = new FeaturesPlatforms(new HashSet<String>(), new HashSet<String>());
+                                result = new FeaturesPlatforms();
                             }
                             FeaturesPlatforms fp = parseFeatureManagerNode(child);
                             result.getFeatures().addAll(fp.getFeatures());
@@ -459,26 +459,17 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                 String content = platformElements.item(j).getTextContent();
                 if (content != null) {
                 	content = content.trim();
-                	if (content.contains(":")) {
-                		String[] contentsplit = content.split(":");
-                		if (contentsplit.length > 2) {
-                			debug("The format of platform " + content + " in the server.xml is not valid and its installation will be skipped.");
-                		} else {
-                			platforms.add(contentsplit[0] + ":" + contentsplit[1].trim().toLowerCase());
-                		}
-                	} else {
-                        if (lowerCaseFeatures) {
-                            content = content.trim().toLowerCase();
-                        } else {
-                            content = content.trim();
-                        }
-                        // Check for empty feature element, skip it and log warning.
-                        if (content.isEmpty()) {
-                            warn("An empty platform was specified in a server configuration file. Ensure that the platforms are valid.");
-                        } else {
-                        	platforms.add(content);
-                        }
-                	}
+                    if (lowerCaseFeatures) {
+                        content = content.trim().toLowerCase();
+                    } else {
+                        content = content.trim();
+                    }
+                    // Check for empty feature element, skip it and log warning.
+                    if (content.isEmpty()) {
+                        warn("An empty platform was specified in a server configuration file. Ensure that the platforms are valid.");
+                    } else {
+                    	platforms.add(content);
+                    }
                 }
             }
         }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -396,8 +396,14 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                                 result = new FeaturesPlatforms();
                             }
                             FeaturesPlatforms fp = parseFeatureManagerNode(child);
-                            result.getFeatures().addAll(fp.getFeatures());
-                            result.getPlatforms().addAll(fp.getPlatforms());
+                            Set<String> featuresToInstall = new HashSet<String>();
+                            Set<String> platformsToInstall = new HashSet<String>();
+                            if (fp != null) {
+                            	featuresToInstall = fp.getFeatures();
+                            	platformsToInstall = fp.getPlatforms();
+                            }
+                            result.getFeatures().addAll(featuresToInstall);
+                            result.getPlatforms().addAll(platformsToInstall);
                         } else if ("include".equals(child.getNodeName())){
                             result = parseIncludeNode(result, serverDirectory, canonicalServerFile, bootstrapProperties, child, updatedParsedXmls);
                         }
@@ -598,7 +604,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
             } // else the parent already has some results (even if it's empty), so ignore the child
         } else {
             // anything else counts as "merge", even if the onConflict value is invalid
-            if (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty()) {
+            if ((fp != null) && (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty())) {
                 if (result.getFeatures().isEmpty() && result.getPlatforms().isEmpty()) {
                     result = fp;
                 } else {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -53,6 +53,7 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+
 import io.openliberty.tools.common.CommonLoggerI;
 
 /**
@@ -83,6 +84,59 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
     private URLClassLoader installMapLoader = null;
     private Class<Map<String, Object>> installMapClass = null;
     protected Map<String, Object> mapBasedInstallKernel= null;
+    
+    public static class FeaturesPlatforms {
+
+        /**
+         * @param features
+         * @param platforms
+         */
+        public FeaturesPlatforms(Set<String> features, Set<String> platforms) {
+            super();
+            this.features = features;
+            this.platforms = platforms;
+        }
+        /**
+         * @param features
+         * @param platforms
+         */
+        public FeaturesPlatforms() {
+            super();
+            this.features = new HashSet<String>();
+            this.platforms = new HashSet<String>();
+        }
+
+        private Set<String> features;
+        private Set<String> platforms;
+
+        /**
+         * @return the features
+         */
+        public Set<String> getFeatures() {
+            return features;
+        }
+
+        /**
+         * @param features the features to set
+         */
+        public void setFeatures(Set<String> features) {
+            this.features = features;
+        }
+
+        /**
+         * @return the platforms
+         */
+        public Set<String> getPlatforms() {
+            return platforms;
+        }
+
+        /**
+         * @param platforms the platforms to set
+         */
+        public void setPlatforms(Set<String> platforms) {
+            this.platforms = platforms;
+        }
+    }
     
     /**
      * Log debug
@@ -154,17 +208,17 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      * @param serverXmlFile The server.xml file
      * @param libertyDirPropFiles Map of Liberty directory properties to the actual File for each directory
      * @param dropinsFilesToIgnore A set of file names under configDropins/overrides or configDropins/defaults to ignore
-     * @return the set of features that should be installed from server.xml, or empty set if nothing should be installed
+     * @return FeaturesPlatforms containing both features and platforms that should be installed from server.xml, or empty set if nothing should be installed
      *         or null if there are no valid xml files or they have no featureManager section
      */
-     public Set<String> getServerFeatures(File serverDirectory, File serverXmlFile, Map<String,File> libertyDirPropFiles, Set<String> dropinsFilesToIgnore) {
+     public FeaturesPlatforms getServerFeatures(File serverDirectory, File serverXmlFile, Map<String,File> libertyDirPropFiles, Set<String> dropinsFilesToIgnore) {
         if (libertyDirPropFiles != null) {
             setLibertyDirectoryPropertyFiles(libertyDirPropFiles);
         } else if (libertyDirectoryPropertyToFile == null) {
             warn("The properties for directories are null and could lead to server include files not being processed for server features.");
         }
         Properties bootstrapProperties = getBootstrapProperties(new File(serverDirectory, "bootstrap.properties"));
-        Set<String> result = getConfigDropinsFeatures(null, serverDirectory, bootstrapProperties, "defaults", dropinsFilesToIgnore);
+        FeaturesPlatforms result = getConfigDropinsFeatures(null, serverDirectory, bootstrapProperties, "defaults", dropinsFilesToIgnore);
         if (serverXmlFile == null) {
             serverXmlFile = new File(serverDirectory, "server.xml");
         }
@@ -180,10 +234,10 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      * @param serverDirectory The server directory containing the server.xml
      * @param libertyDirPropFiles Map of Liberty directory properties to the actual File for each directory
      * @param dropinsFilesToIgnore A set of file names under configDropins/overrides or configDropins/defaults to ignore
-     * @return the set of features that should be installed from server.xml, or empty set if nothing should be installed
+     * @return FeaturesPlatforms containing both features and platforms that should be installed from server.xml, or empty set if nothing should be installed
      *         or null if there are no valid xml files or they have no featureManager section
      */
-    public Set<String> getServerFeatures(File serverDirectory, Map<String,File> libertyDirPropFiles, Set<String> dropinsFilesToIgnore) {
+    public FeaturesPlatforms getServerFeatures(File serverDirectory, Map<String,File> libertyDirPropFiles, Set<String> dropinsFilesToIgnore) {
         return getServerFeatures(serverDirectory, new File(serverDirectory, "server.xml"), libertyDirPropFiles, dropinsFilesToIgnore);
     }
 
@@ -191,10 +245,10 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      * Get the set of features defined in the server.xml
      * @param serverDirectory The server directory containing the server.xml
      * @param libertyDirPropFiles Map of Liberty directory properties to the actual File for each directory
-     * @return the set of features that should be installed from server.xml, or empty set if nothing should be installed
+     * @return FeaturesPlatforms containing both features and platforms that should be installed from server.xml, or empty set if nothing should be installed
      *         or null if there are no valid xml files or they have no featureManager section
      */
-    public Set<String> getServerFeatures(File serverDirectory, Map<String,File> libertyDirPropFiles) {
+    public FeaturesPlatforms getServerFeatures(File serverDirectory, Map<String,File> libertyDirPropFiles) {
         return getServerFeatures(serverDirectory, libertyDirPropFiles, null);
     }
 
@@ -227,13 +281,13 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      *                             or "overrides"
      * @param dropinsFilesToIgnore A set of file names under the given folderName
      *                             that should be ignored
-     * @return The set of features to install, or empty set if the cumulatively
+     * @return The FeaturesPlatforms containing both features and platforms to install, or empty set if the cumulatively
      *         parsed xml files only have featureManager sections but no features to
      *         install, or null if there are no valid xml files or they have no
      *         featureManager section
      */
-    private Set<String> getConfigDropinsFeatures(Set<String> origResult, File serverDirectory, Properties bootstrapProperties, String folderName, final Set<String> dropinsFilesToIgnore) {
-        Set<String> result = origResult;
+    private FeaturesPlatforms getConfigDropinsFeatures(FeaturesPlatforms origResult, File serverDirectory, Properties bootstrapProperties, String folderName, final Set<String> dropinsFilesToIgnore) {
+    	FeaturesPlatforms result = origResult;
         File configDropinsFolder;
         try {
             configDropinsFolder = new File(new File(serverDirectory, "configDropins"), folderName).getCanonicalFile();
@@ -262,9 +316,9 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         Collections.sort(Arrays.asList(configDropinsXmls), comparator);
 
         for (File xml : configDropinsXmls) {
-            Set<String> features = getServerXmlFeatures(result, serverDirectory, xml, bootstrapProperties,null);
-            if (features != null) {
-                result = features;
+        	FeaturesPlatforms fp = getServerXmlFeatures(result, serverDirectory, xml, bootstrapProperties,null);
+            if (fp!=null && (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty())) {
+                result = fp;
             }
         }
         return result;
@@ -289,8 +343,8 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      *         features to install, or null if there are no valid xml files or
      *         they have no featureManager section
      */
-    public Set<String> getServerXmlFeatures(Set<String> origResult, File serverDirectory, File serverFile, Properties bootstrapProperties, List<File> parsedXmls) {
-        Set<String> result = origResult;
+    public FeaturesPlatforms getServerXmlFeatures(FeaturesPlatforms origResult, File serverDirectory, File serverFile, Properties bootstrapProperties, List<File> parsedXmls) {
+    	FeaturesPlatforms result = origResult;
         List<File> updatedParsedXmls = parsedXmls != null ? parsedXmls : new ArrayList<File>();
         File canonicalServerFile;
         try {
@@ -339,9 +393,11 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                         Element child = (Element) nodes.item(i);
                         if ("featureManager".equals(child.getNodeName())) {
                             if (result == null) {
-                                result = new HashSet<String>();
+                                result = new FeaturesPlatforms(new HashSet<String>(), new HashSet<String>());
                             }
-                            result.addAll(parseFeatureManagerNode(child));
+                            FeaturesPlatforms fp = parseFeatureManagerNode(child);
+                            result.getFeatures().addAll(fp.getFeatures());
+                            result.getPlatforms().addAll(fp.getPlatforms());
                         } else if ("include".equals(child.getNodeName())){
                             result = parseIncludeNode(result, serverDirectory, canonicalServerFile, bootstrapProperties, child, updatedParsedXmls);
                         }
@@ -363,14 +419,15 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      * 
      * @param node
      *            The featureManager node
-     * @return Set of trimmed lowercase feature names
+     * @return FeaturesPlatforms holding both trimmed lowercase feature names and platform names
      */
-    private Set<String> parseFeatureManagerNode(Element node) {
-        Set<String> result = new HashSet<String>();
-        NodeList features = node.getElementsByTagName("feature");
-        if (features != null) {
-            for (int j = 0; j < features.getLength(); j++) {
-                String content = features.item(j).getTextContent();
+    private FeaturesPlatforms parseFeatureManagerNode(Element node) {
+        Set<String> features = new HashSet<String>();
+        Set<String> platforms = new HashSet<String>();
+        NodeList featureElements = node.getElementsByTagName("feature");
+        if (featureElements != null) {
+            for (int j = 0; j < featureElements.getLength(); j++) {
+                String content = featureElements.item(j).getTextContent();
                 if (content != null) {
                 	content = content.trim();
                 	if (content.contains(":")) {
@@ -378,7 +435,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                 		if (contentsplit.length > 2) {
                 			debug("The format of feature " + content + " in the server.xml is not valid and its installation will be skipped.");
                 		} else {
-                			result.add(contentsplit[0] + ":" + contentsplit[1].trim().toLowerCase());
+                			features.add(contentsplit[0] + ":" + contentsplit[1].trim().toLowerCase());
                 		}
                 	} else {
                         if (lowerCaseFeatures) {
@@ -390,19 +447,48 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
                         if (content.isEmpty()) {
                             warn("An empty feature was specified in a server configuration file. Ensure that the features are valid.");
                         } else {
-                            result.add(content);
+                        	features.add(content);
                         }
                 	}
                 }
             }
         }
-        return result;
+        NodeList platformElements = node.getElementsByTagName("platform");
+        if (platformElements != null) {
+            for (int j = 0; j < platformElements.getLength(); j++) {
+                String content = platformElements.item(j).getTextContent();
+                if (content != null) {
+                	content = content.trim();
+                	if (content.contains(":")) {
+                		String[] contentsplit = content.split(":");
+                		if (contentsplit.length > 2) {
+                			debug("The format of platform " + content + " in the server.xml is not valid and its installation will be skipped.");
+                		} else {
+                			platforms.add(contentsplit[0] + ":" + contentsplit[1].trim().toLowerCase());
+                		}
+                	} else {
+                        if (lowerCaseFeatures) {
+                            content = content.trim().toLowerCase();
+                        } else {
+                            content = content.trim();
+                        }
+                        // Check for empty feature element, skip it and log warning.
+                        if (content.isEmpty()) {
+                            warn("An empty platform was specified in a server configuration file. Ensure that the platforms are valid.");
+                        } else {
+                        	platforms.add(content);
+                        }
+                	}
+                }
+            }
+        }
+        return new FeaturesPlatforms(features, platforms);
     }
     
     /**
      * Parse features from an include node.
      * 
-     * @param origResult
+     * @param result2
      *            The features that have been parsed so far.
      * @param serverDirectory
      *            The server directory containing the server.xml.
@@ -418,9 +504,9 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
      *         they have no featureManager section
      * @throws IOException
      */
-    private Set<String> parseIncludeNode(Set<String> origResult, File serverDirectory, File serverFile, Properties bootstrapProperties, Element node,
+    private FeaturesPlatforms parseIncludeNode(FeaturesPlatforms origResult, File serverDirectory, File serverFile, Properties bootstrapProperties, Element node,
             List<File> updatedParsedXmls) {
-        Set<String> result = origResult;
+    	FeaturesPlatforms result = origResult;
         // Need to handle more variable substitution for include location.
         String nodeValue = node.getAttribute("location");
         String includeFileName = VariableUtility.resolveVariables(this, nodeValue, null, bootstrapProperties, new Properties(), getLibertyDirectoryPropertyFiles());
@@ -464,11 +550,11 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         for (File file : includeFiles) {
             if (!updatedParsedXmls.contains(file)) {
                 String onConflict = node.getAttribute("onConflict");
-                Set<String> features = getServerXmlFeatures(null, serverDirectory, file, bootstrapProperties, updatedParsedXmls);
-                if (features != null && !features.isEmpty()) {
+                FeaturesPlatforms fp = getServerXmlFeatures(null, serverDirectory, file, bootstrapProperties, updatedParsedXmls);
+                if (fp != null && !fp.getFeatures().isEmpty()) {
                     info("Features were included for file "+ file.toString());
                 }
-                result = handleOnConflict(result, onConflict, features);
+                result = handleOnConflict(result, onConflict, fp);
             }
         }
         return result;
@@ -507,25 +593,26 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         }
     }
     
-    private Set<String> handleOnConflict(Set<String> origResult, String onConflict, Set<String> features) {
-        Set<String> result = origResult;
+    private FeaturesPlatforms handleOnConflict(FeaturesPlatforms origResult, String onConflict, FeaturesPlatforms fp) {
+    	FeaturesPlatforms result = origResult;
         if ("replace".equalsIgnoreCase(onConflict)) {
-            if (features != null && !features.isEmpty()) {
-                // only replace if the child has features
-                result = features;
+            if (fp != null && (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty())) {
+                // only replace if the child has features or platforms
+                result = fp;
             }
         } else if ("ignore".equalsIgnoreCase(onConflict)) {
             if (result == null) {
                 // parent has no results (i.e. no featureManager section), so use the child's results
-                result = features;
+                result = fp;
             } // else the parent already has some results (even if it's empty), so ignore the child
         } else {
             // anything else counts as "merge", even if the onConflict value is invalid
-            if (features != null) {
-                if (result == null) {
-                    result = features;
+            if (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty()) {
+                if (result.getFeatures().isEmpty() && result.getPlatforms().isEmpty()) {
+                    result = fp;
                 } else {
-                    result.addAll(features);
+                    result.getFeatures().addAll(fp.getFeatures());
+                    result.getPlatforms().addAll(fp.getPlatforms());
                 }
             }
         }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -71,22 +71,40 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     
     private void verifyServerFeatures(Set<String> expected) throws Exception {
     	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
+    	Set<String> featuresToInstall = new HashSet<String>();
+        if (getServerResult != null) {
+        	featuresToInstall = getServerResult.getFeatures();
+        }
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, featuresToInstall);
     }
     private void verifyServerFeaturesAndPlatforms(Set<String> expectedFeatures,Set<String> expectedPlatforms) throws Exception {
     	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expectedFeatures, getServerResult.getFeatures());
-        assertEquals("The platforms returned from getServerFeatures do not equal the expected platforms.", expectedPlatforms, getServerResult.getPlatforms());
+    	Set<String> featuresToInstall = new HashSet<String>();
+        Set<String> platformsToInstall = new HashSet<String>();
+        if (getServerResult != null) {
+        	featuresToInstall = getServerResult.getFeatures();
+        	platformsToInstall = getServerResult.getPlatforms();
+        }
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expectedFeatures, featuresToInstall);
+        assertEquals("The platforms returned from getServerFeatures do not equal the expected platforms.", expectedPlatforms, platformsToInstall);
     }
     private void verifyServerFeatures(Set<String> expected, Set<String> ignoreFiles) throws Exception {
     	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null, ignoreFiles);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
+    	Set<String> featuresToInstall = new HashSet<String>();
+        if (getServerResult != null) {
+        	featuresToInstall = getServerResult.getFeatures();
+        }
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, featuresToInstall);
     }
     
     private void verifyServerFeaturesPreserveCase(Set<String> expected) throws Exception {
         util.setLowerCaseFeatures(false);
         FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
+        Set<String> featuresToInstall = new HashSet<String>();
+        if (getServerResult != null) {
+        	featuresToInstall = getServerResult.getFeatures();
+        }
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, featuresToInstall);
         util.setLowerCaseFeatures(true); // restore default
     }
     

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -73,6 +73,11 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
         assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
     }
+    private void verifyServerFeaturesAndPlatforms(Set<String> expectedFeatures,Set<String> expectedPlatforms) throws Exception {
+    	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expectedFeatures, getServerResult.getFeatures());
+        assertEquals("The platforms returned from getServerFeatures do not equal the expected platforms.", expectedPlatforms, getServerResult.getPlatforms());
+    }
     private void verifyServerFeatures(Set<String> expected, Set<String> ignoreFiles) throws Exception {
     	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null, ignoreFiles);
         assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
@@ -251,6 +256,30 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     }
     
     /**
+     * Tests server.xml with both config dropins overrides and defaults
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOverridesAndDefaultsWithPlatforms() throws Exception{
+        copy("server.xml");
+        copyAsName("config_overrides.xml", "configDropins/overrides/config_overrides.xml");
+        copyAsName("config_defaults.xml", "configDropins/defaults/config_defaults.xml");
+        
+        Set<String> expectedFeatures = new HashSet<String>();
+        expectedFeatures.add("orig");
+        expectedFeatures.add("overrides");
+        expectedFeatures.add("defaults");
+        
+        Set<String> expectedPlatforms = new HashSet<String>();
+        expectedPlatforms.add("plat-1.0");
+        expectedPlatforms.add("plat-overrides");
+        expectedPlatforms.add("plat-defaults");
+
+        verifyServerFeaturesAndPlatforms(expectedFeatures,expectedPlatforms);
+    }
+    
+    /**
      * Tests server.xml with multiple MERGE functions
      * 
      * @throws Exception
@@ -267,6 +296,29 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         expected.add("extra3");
 
         verifyServerFeatures(expected);
+    }
+    
+    /**
+     * Tests server.xml with multiple MERGE functions
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMultipleMergeWithPlatforms() throws Exception{
+        copyAsName("server_multiple_merge.xml", "server.xml");
+        copy("extraFeatures2.xml");
+        copy("extraFeatures3.xml");
+
+        Set<String> expectedFeatures = new HashSet<String>();
+        expectedFeatures.add("orig");
+        expectedFeatures.add("extra2");
+        expectedFeatures.add("extra3");
+        
+        Set<String> expectedPlatforms = new HashSet<String>();
+        expectedPlatforms.add("plat-1.0");
+        expectedPlatforms.add("plat-2.0");
+
+        verifyServerFeaturesAndPlatforms(expectedFeatures,expectedPlatforms);
     }
     
     /**

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -34,6 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import io.openliberty.tools.common.plugins.util.ServerFeatureUtil.FeaturesPlatforms;
+
 public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureUtilTest {
     private static File serverDirectory = null;
     private static File src = null;
@@ -68,18 +70,18 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     }
     
     private void verifyServerFeatures(Set<String> expected) throws Exception {
-        Set<String> getServerResult = util.getServerFeatures(serverDirectory, null);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult);
+    	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
     }
     private void verifyServerFeatures(Set<String> expected, Set<String> ignoreFiles) throws Exception {
-        Set<String> getServerResult = util.getServerFeatures(serverDirectory, null, ignoreFiles);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult);
+    	FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null, ignoreFiles);
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
     }
     
     private void verifyServerFeaturesPreserveCase(Set<String> expected) throws Exception {
         util.setLowerCaseFeatures(false);
-        Set<String> getServerResult = util.getServerFeatures(serverDirectory, null);
-        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult);
+        FeaturesPlatforms getServerResult = util.getServerFeatures(serverDirectory, null);
+        assertEquals("The features returned from getServerFeatures do not equal the expected features.", expected, getServerResult.getFeatures());
         util.setLowerCaseFeatures(true); // restore default
     }
     

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilTest.java
@@ -95,7 +95,7 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         InstallFeatureUtil util = getNewInstallFeatureUtil();
         List<String> featuresToInstall = new ArrayList<String>();
         featuresToInstall.add("a-1.0");
-        util.installFeatures(true, featuresToInstall);
+        util.installFeatures(true, featuresToInstall, new ArrayList<String>());
     }
     
     @Test

--- a/src/test/resources/servers/config_defaults.xml
+++ b/src/test/resources/servers/config_defaults.xml
@@ -2,5 +2,6 @@
 <server description="new server">
     <featureManager>
         <feature>defaults</feature>
+        <platform>plat-defaults</platform>
     </featureManager>
 </server>

--- a/src/test/resources/servers/config_overrides.xml
+++ b/src/test/resources/servers/config_overrides.xml
@@ -2,5 +2,6 @@
 <server description="new server">
     <featureManager>
         <feature>overrides</feature>
+        <platform>plat-overrides</platform>
     </featureManager>
 </server>

--- a/src/test/resources/servers/extraFeatures2.xml
+++ b/src/test/resources/servers/extraFeatures2.xml
@@ -2,5 +2,6 @@
 <server description="new server">
 	<featureManager>
         <feature>extra2</feature>
+        <platform>plat-2.0</platform>
     </featureManager>
 </server>

--- a/src/test/resources/servers/server.xml
+++ b/src/test/resources/servers/server.xml
@@ -2,5 +2,6 @@
 <server description="new server">
     <featureManager>
         <feature>orig</feature>
+        <platform>plat-1.0</platform>
     </featureManager>
 </server>

--- a/src/test/resources/servers/server_multiple_merge.xml
+++ b/src/test/resources/servers/server_multiple_merge.xml
@@ -2,6 +2,7 @@
 <server description="new server">
     <featureManager>
         <feature>orig</feature>
+        <platform>plat-1.0</platform>
     </featureManager>
     <include location="extraFeatures2.xml" onConflict="MERGE"/>
     <include location="extraFeatures3.xml" onConflict="MERGE"/>


### PR DESCRIPTION
The parsing logic now collects `<platform>` elements along with `<features>`