### PR TITLE
Update min version to 24.0.0.9 for versionless features

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -113,7 +113,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
     private static final String TO_USER = "usr";
     private static final String MIN_USER_FEATURE_VERSION = "21.0.0.11";
     private static final String MIN_VERIFY_FEATURE_VERSION = "23.0.0.9";
-    private static final String MIN_VERSIONLESS_FEATURE_VERSION = "24.0.0.8";
+    private static final String MIN_VERSIONLESS_FEATURE_VERSION = "24.0.0.9";
 
     private String openLibertyVersion;
     private static Boolean saveURLCacheStatus = null;


### PR DESCRIPTION
Versionless feature support was added in 24.0.0.8, but some important fixes went into 24.0.0.9. Better to steer people to use that version.