### PR TITLE
Prevent NPE for nested include files with no featureManager element

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java
@@ -612,7 +612,7 @@ public abstract class ServerFeatureUtil extends AbstractContainerSupportUtil imp
         } else {
             // anything else counts as "merge", even if the onConflict value is invalid
             if ((fp != null) && (!fp.getFeatures().isEmpty() || !fp.getPlatforms().isEmpty())) {
-                if (result.getFeatures().isEmpty() && result.getPlatforms().isEmpty()) {
+                if ((result == null) || (result.getFeatures().isEmpty() && result.getPlatforms().isEmpty())) {
                     result = fp;
                 } else {
                     result.getFeatures().addAll(fp.getFeatures());

--- a/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -157,6 +157,24 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
     }
     
     /**
+     * Tests server.xml with MERGE function with nested include files, one of which contains no featureManager
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNestedMergeServerXML() throws Exception{
+        copyAsName("server_merge_nested.xml", "server.xml");
+        copy("extraFeatures.xml");
+        copy("noList_nested_features.xml");
+
+        Set<String> expected = new HashSet<String>();
+        expected.add("orig");
+        expected.add("extra");
+
+        verifyServerFeatures(expected);
+    }
+
+    /**
      * Tests server.xml with REPLACE function
      * 
      * @throws Exception

--- a/src/test/resources/servers/noList_nested_features.xml
+++ b/src/test/resources/servers/noList_nested_features.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <include location="extraFeatures.xml" onConflict="MERGE"/>
+</server>

--- a/src/test/resources/servers/server_merge_nested.xml
+++ b/src/test/resources/servers/server_merge_nested.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <featureManager>
+        <feature>orig</feature>
+    </featureManager>
+    <include location="noList_nested_features.xml" onConflict="MERGE"/>
+</server>


### PR DESCRIPTION
Before this fix, the additional test case added by this PR received the following exception:

```
[ERROR] Errors: 
[ERROR]   InstallFeatureUtilGetServerFeaturesTest.testNestedMergeServerXML:174->verifyServerFeatures:73 » NullPointer Cannot invoke "io.openliberty.tools.common.plugins.util.ServerFeatureUtil$FeaturesPlatforms.getFeatures()" because "result" is null
```

Related to https://github.com/OpenLiberty/ci.maven/issues/1838

