### PR TITLE
fix for generating configDropins even if user specify springbootappli…

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/config/ServerConfigDocument.java
@@ -495,7 +495,7 @@ public class ServerConfigDocument {
 
         NodeList nodeList = (NodeList) expression.evaluate(doc, XPathConstants.NODESET);
         if(expression.equals(XPATH_SERVER_SPRINGBOOT_APPLICATION) && nodeList.getLength()>1){
-            throw new PluginExecutionException("Multiple <springBootApplication/> nodes found in Liberty Config server.xml. Please specify only one");
+            throw new PluginExecutionException("Found multiple springBootApplication elements specified in the server configuration. Only one springBootApplication can be configured per Liberty server.");
         }
         for (int i = 0; i < nodeList.getLength(); i++) {
             String nodeValue = nodeList.item(i).getAttributes().getNamedItem("location").getNodeValue();

--- a/src/test/java/io/openliberty/tools/common/config/ServerConfigDocumentOverridesTest.java
+++ b/src/test/java/io/openliberty/tools/common/config/ServerConfigDocumentOverridesTest.java
@@ -261,10 +261,11 @@ public class ServerConfigDocumentOverridesTest {
         File serversResourceDir = SERVERS_RESOURCES_DIR.toFile();
         File springBootServerXmlDir = new File(serversResourceDir, "springBootApplicationTest");
         File serverXml = new File(springBootServerXmlDir, "invalid_server.xml");
-        File newServerXml=new File(springBootServerXmlDir, "server.xml");
-        Files.copy(serverXml.toPath(),newServerXml.toPath(),StandardCopyOption.REPLACE_EXISTING);
+        File newServerXml = new File(springBootServerXmlDir, "server.xml");
+        Files.copy(serverXml.toPath(), newServerXml.toPath(), StandardCopyOption.REPLACE_EXISTING);
         Map<String, File> libertyDirPropMap = new HashMap<>();
         libertyDirPropMap.put(ServerFeatureUtil.SERVER_CONFIG_DIR, springBootServerXmlDir);
-        assertThrows(PluginExecutionException.class, ()->new ServerConfigDocument(new TestLogger(), null, libertyDirPropMap));
+        assertThrows("Found multiple springBootApplication elements specified in the server configuration. Only one springBootApplication can be configured per Liberty server.",
+                PluginExecutionException.class, () -> new ServerConfigDocument(new TestLogger(), null, libertyDirPropMap));
     }
 }

--- a/src/test/java/io/openliberty/tools/common/config/ServerConfigDocumentOverridesTest.java
+++ b/src/test/java/io/openliberty/tools/common/config/ServerConfigDocumentOverridesTest.java
@@ -1,5 +1,7 @@
 package io.openliberty.tools.common.config;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -7,14 +9,17 @@ import static org.junit.Assert.assertFalse;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import javax.xml.xpath.XPathExpressionException;
 
+import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -206,7 +211,7 @@ public class ServerConfigDocumentOverridesTest {
 
     // Run the method
     @Test
-    public void initializeAppsLocationTest() {
+    public void initializeAppsLocationTest() throws PluginExecutionException {
         File serverConfigDir = SERVER_CONFIG_DIR.toFile();
         Map<String, File> libertyDirPropMap = new HashMap<String, File>();
         libertyDirPropMap.put(ServerFeatureUtil.SERVER_CONFIG_DIR, serverConfigDir);
@@ -235,5 +240,31 @@ public class ServerConfigDocumentOverridesTest {
         assertEquals("The value is expected to be overriden from false to true","true", properties.get("variables.override"));
         // configDropins, overrides variable dir
         assertEquals("The value is expected to be overriden from 9080 to 7777","7777", properties.get("httpPort"));
+    }
+
+   @Test
+    public void testProcessServerXmlWithSpringBootApplicationNode() throws IOException, PluginExecutionException {
+        File serversResourceDir = SERVERS_RESOURCES_DIR.toFile();
+        File springBootServerXmlDir = new File(serversResourceDir, "springBootApplicationTest");
+        File serverXml = new File(springBootServerXmlDir, "valid_server.xml");
+        File newServerXml=new File(springBootServerXmlDir, "server.xml");
+        Files.copy(serverXml.toPath(),newServerXml.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        Map<String, File> libertyDirPropMap = new HashMap<>();
+        libertyDirPropMap.put(ServerFeatureUtil.SERVER_CONFIG_DIR, springBootServerXmlDir);
+        ServerConfigDocument configDocument = new ServerConfigDocument(new TestLogger(), null, libertyDirPropMap);
+        assertTrue("ServerConfigDocument getSpringBootAppNodeLocation should not be empty  ",configDocument.getSpringBootAppNodeLocation().isPresent());
+        assertEquals("ServerConfigDocument locations does not contain expected  ", "guide-spring-boot-0.1.0.jar", configDocument.getSpringBootAppNodeLocation().get());
+    }
+
+    @Test
+    public void testProcessServerXmlWithMultipleSpringBootNodes() throws IOException {
+        File serversResourceDir = SERVERS_RESOURCES_DIR.toFile();
+        File springBootServerXmlDir = new File(serversResourceDir, "springBootApplicationTest");
+        File serverXml = new File(springBootServerXmlDir, "invalid_server.xml");
+        File newServerXml=new File(springBootServerXmlDir, "server.xml");
+        Files.copy(serverXml.toPath(),newServerXml.toPath(),StandardCopyOption.REPLACE_EXISTING);
+        Map<String, File> libertyDirPropMap = new HashMap<>();
+        libertyDirPropMap.put(ServerFeatureUtil.SERVER_CONFIG_DIR, springBootServerXmlDir);
+        assertThrows(PluginExecutionException.class, ()->new ServerConfigDocument(new TestLogger(), null, libertyDirPropMap));
     }
 }

--- a/src/test/resources/servers/springBootApplicationTest/invalid_server.xml
+++ b/src/test/resources/servers/springBootApplicationTest/invalid_server.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>springBoot-3.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+    <springBootApplication id="guide-spring-boot"
+                           location="guide-spring-boot-0.1.0.jar"
+                           name="guide-spring-boot" />
+    <springBootApplication id="guide-spring-boot"
+                           location="guide-spring-boot-0.1.0.jar"
+                           name="guide-spring-boot" />
+</server>

--- a/src/test/resources/servers/springBootApplicationTest/invalid_server.xml
+++ b/src/test/resources/servers/springBootApplicationTest/invalid_server.xml
@@ -14,6 +14,6 @@
                            location="guide-spring-boot-0.1.0.jar"
                            name="guide-spring-boot" />
     <springBootApplication id="guide-spring-boot"
-                           location="guide-spring-boot-0.1.0.jar"
+                           location="guide-spring-boot-0.2.0.jar"
                            name="guide-spring-boot" />
 </server>

--- a/src/test/resources/servers/springBootApplicationTest/server.xml
+++ b/src/test/resources/servers/springBootApplicationTest/server.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>springBoot-3.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+    <springBootApplication id="guide-spring-boot"
+                           location="guide-spring-boot-0.1.0.jar"
+                           name="guide-spring-boot" />
+    <springBootApplication id="guide-spring-boot"
+                           location="guide-spring-boot-0.1.0.jar"
+                           name="guide-spring-boot" />
+</server>

--- a/src/test/resources/servers/springBootApplicationTest/valid_server.xml
+++ b/src/test/resources/servers/springBootApplicationTest/valid_server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>springBoot-3.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+    <springBootApplication id="guide-spring-boot"
+                           location="guide-spring-boot-0.1.0.jar"
+                           name="guide-spring-boot" />
+</server>


### PR DESCRIPTION
fix for issue of generating configDropins even if user specify springbootapplcation node in server.xml
Ideally this should create thin springboot application with the same location attribute of <springBootApplication/> node