### PR TITLE
MIN_VERSIONLESS_FEATURE_VERSION too high

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -113,7 +113,7 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
     private static final String TO_USER = "usr";
     private static final String MIN_USER_FEATURE_VERSION = "21.0.0.11";
     private static final String MIN_VERIFY_FEATURE_VERSION = "23.0.0.9";
-    private static final String MIN_VERSIONLESS_FEATURE_VERSION = "24.0.0.10";
+    private static final String MIN_VERSIONLESS_FEATURE_VERSION = "24.0.0.8";
 
     private String openLibertyVersion;
     private static Boolean saveURLCacheStatus = null;


### PR DESCRIPTION
Versionless is supported since 24.0.0.8
https://github.com/OpenLiberty/ci.common/issues/472