### PR TITLE
Specify version 24.0.0.2 for binary scanner

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/BinaryScannerUtil.java
@@ -30,7 +30,7 @@ public abstract class BinaryScannerUtil {
     public static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
     public static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
     public static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
-    public static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.5-SNAPSHOT,)";
+    public static final String BINARY_SCANNER_MAVEN_VERSION = "[24.0.0.2]";
 
     public static final String GENERATED_FEATURES_FILE_NAME = "generated-features.xml";
     public static final String GENERATED_FEATURES_FILE_PATH = "configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;


### PR DESCRIPTION
This specifies the latest binary scanner on Maven Central.

Responding to https://github.com/OpenLiberty/ci.maven/issues/1874