### PR TITLE
 https port parsing logic fixed for json message format

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2049,7 +2049,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             // if no ending slash, the port ends at the end of the message
             portEndIndex = webAppMessage.length();
         }
-        String parsedHttpPort = webAppMessage.substring(portIndex, portEndIndex).replaceAll("/","").replace("\\","");
+        String parsedHttpPort = webAppMessage.substring(portIndex, portEndIndex).replace("/","").replace("\\","");
         debug("Parsed http port: " + parsedHttpPort);
         if (container) {
             httpPort = findLocalPort(parsedHttpPort);

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
@@ -60,6 +60,7 @@ public class DevUtilHostnamePortTest extends BaseDevUtilTest {
     }
 
     private final String[] tcpChannelTranslations = {
+        "{\"type\":\"liberty_message\",\"host\":\"46410dbe01bd\",\"ibm_userDir\":\"\\/opt\\/ol\\/wlp\\/usr\\/\",\"ibm_serverName\":\"defaultServer\",\"message\":\"CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host {1}  (IPv6) port {2}.\",\"ibm_threadId\":\"00000033\",\"ibm_datetime\":\"2025-08-25T03:59:03.002+0000\",\"ibm_messageId\":\"CWWKO0219I\",\"module\":\"com.ibm.ws.tcpchannel.internal.TCPPort\",\"loglevel\":\"INFO\",\"ibm_sequence\":\"1756094343002_0000000000023\",\"ext_thread\":\"Default Executor-thread-1\"\n}",
         "CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host {1} port {2}.",
         "CWWKO0219I: Kan\u00e1l TCP {0} byl spu\u0161t\u011bn a nyn\u00ed naslouch\u00e1 po\u017eadavk\u016fm na hostiteli {1} na portu {2}.",
         "CWWKO0219I: Der TCP-Kanal {0} wurde gestartet und ist jetzt f\u00fcr Anforderungen auf dem Host {1} an Port {2} empfangsbereit.",

--- a/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/DevUtilHostnamePortTest.java
@@ -41,6 +41,16 @@ public class DevUtilHostnamePortTest extends BaseDevUtilTest {
     }
 
     @Test
+    public void testParseHostnameHttpPortWithEscaped() throws Exception {
+        testHostnameAndHttpPort("Web application available (default_host):http:\\/\\/myhostname:9085");
+    }
+
+    @Test
+    public void testParseHostnameHttpPortWithEscaped2() throws Exception {
+        testHostnameAndHttpPort("Web application available (default_host): http:\\/\\/myhostname:9085\\/ifix\\/");
+    }
+
+    @Test
     public void testParseHostnameHttpPortFromHttps() throws Exception {
         String message = "Web application available (default_host): https://myhostname:9085/myapp/";
 
@@ -60,7 +70,9 @@ public class DevUtilHostnamePortTest extends BaseDevUtilTest {
     }
 
     private final String[] tcpChannelTranslations = {
-        "{\"type\":\"liberty_message\",\"host\":\"46410dbe01bd\",\"ibm_userDir\":\"\\/opt\\/ol\\/wlp\\/usr\\/\",\"ibm_serverName\":\"defaultServer\",\"message\":\"CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host {1}  (IPv6) port {2}.\",\"ibm_threadId\":\"00000033\",\"ibm_datetime\":\"2025-08-25T03:59:03.002+0000\",\"ibm_messageId\":\"CWWKO0219I\",\"module\":\"com.ibm.ws.tcpchannel.internal.TCPPort\",\"loglevel\":\"INFO\",\"ibm_sequence\":\"1756094343002_0000000000023\",\"ext_thread\":\"Default Executor-thread-1\"\n}",
+        "{\"type\":\"liberty_message\",\"host\":\"46410dbe01bd\",\"ibm_userDir\":\"\\/opt\\/ol\\/wlp\\/usr\\/\",\"ibm_serverName\":\"defaultServer\",\"message\":\"CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host {1}  (IPv6) port {2}.\",\"ibm_threadId\":\"00000033\",\"ibm_datetime\":\"2025-08-25T03:59:03.002+0000\",\"ibm_messageId\":\"CWWKO0219I\",\"module\":\"com.ibm.ws.tcpchannel.internal.TCPPort\",\"loglevel\":\"INFO\",\"ibm_sequence\":\"1756094343002_0000000000023\",\"ext_thread\":\"Default Executor-thread-1\"}",
+        "[8/25/25, 13:29:17:236 UTC] 00000033 com.ibm.ws.tcpchannel.internal.TCPPort                       I CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host *  (IPv6) port {2}.",
+        "[8/25/25, 13:36:19:701 UTC] 00000033 TCPPort       I   CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host *  (IPv6) port {2}.",
         "CWWKO0219I: TCP Channel {0} has been started and is now listening for requests on host {1} port {2}.",
         "CWWKO0219I: Kan\u00e1l TCP {0} byl spu\u0161t\u011bn a nyn\u00ed naslouch\u00e1 po\u017eadavk\u016fm na hostiteli {1} na portu {2}.",
         "CWWKO0219I: Der TCP-Kanal {0} wurde gestartet und ist jetzt f\u00fcr Anforderungen auf dem Host {1} an Port {2} empfangsbereit.",


### PR DESCRIPTION
Added logic to parse message in json format

Fixes https://github.com/OpenLiberty/ci.maven/issues/1923

run mvn liberty:devc for sample project shared in issue
https://github.com/adityarao2005/open-liberty-docker-devc-break-example

port in message is parsed successfully and showing properly in warning message

<img width="1228" height="306" alt="Screenshot 2025-08-25 at 10 54 56 AM" src="https://github.com/user-attachments/assets/f18c34e5-b082-4d88-a2a6-433d9f4a564f" />


PR's for testing in 
* ci.maven https://github.com/OpenLiberty/ci.maven/pull/1924
* ci.gradle https://github.com/OpenLiberty/ci.gradle/pull/992