### PR TITLE
Make optimizeGenerateFeatures() available to ci.maven and ci.gradle

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -3447,15 +3447,6 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     /**
      * 
-     * @return {@code Collection<String>} of class paths
-     * @throws IOException
-     */
-    public Collection<String> getJavaSourceClassPaths() throws IOException {
-        return getClassPaths(modifiedClasses);
-    }
-
-    /**
-     * 
      * @param classFiles javaSourceClassFiles that have been modified
      * @return {@code Collection<String>} of class paths
      * @throws IOException

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2755,7 +2755,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         logFeatureGenerationStatus();
     }
 
-    private boolean optimizeGenerateFeatures(boolean useTmpDir) {
+    protected boolean optimizeGenerateFeatures(boolean useTmpDir) {
         debug("Entering optimizeGenerateFeatures(boolean)");
         return optimizeGenerateFeatures(useTmpDir, false);
     }
@@ -2763,7 +2763,7 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
     /**
      * Generate features using all classes and only user specified features.
      */
-    private boolean optimizeGenerateFeatures(boolean useTmpDirOut, boolean useTmpDirIn) {
+    protected boolean optimizeGenerateFeatures(boolean useTmpDirOut, boolean useTmpDirIn) {
         debug("Generating optimized features list...use temp directory for output=" + useTmpDirOut + " use temp directory for input=" + useTmpDirIn);
         // scan all class files and provide only user specified features
         boolean generatedFeatures = libertyGenerateFeatures(null, true, generateToSrc, useTmpDirOut, useTmpDirIn);


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/ci.maven/issues/1967

Add a boolean to track when generate-features.xml is copied to the server as part of modifications to server.xml or pom.xml. When it is copied "early" we can avoid copying it a second time when handling changes to config files. 

Remove unused method.

Make `optimizeGenerateFeatures()` available to ci.maven.