### PR TITLE
adding JAVA_HOME env variable for product info based on java.home

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/InstallFeatureUtil.java
@@ -1151,7 +1151,14 @@ public abstract class InstallFeatureUtil extends ServerFeatureUtil {
             } else {
                 productInfoFile = installDirectory + "/bin/productInfo";
             }
+
             ProcessBuilder pb = new ProcessBuilder(productInfoFile, action);
+            Properties sysp = System.getProperties();
+            String javaHome = sysp.getProperty("java.home");
+            if (javaHome != null) {
+                pb.environment().put("JAVA_HOME", javaHome);
+            }
+            pb.redirectErrorStream(true);
             pr = pb.start();
 
             in = new BufferedReader(new InputStreamReader(pr.getInputStream()));


### PR DESCRIPTION
Fixing https://github.com/OpenLiberty/ci.gradle/issues/1060


Similar code is already present in ci.ant for server task and we are adding for ProductInfo

https://github.com/OpenLiberty/ci.ant/blob/26245d3e002293b4babc1efde6f3ab7089a51521/src/main/java/io/openliberty/tools/ant/ServerTask.java#L113

<img width="819" height="564" alt="image" src="https://github.com/user-attachments/assets/fd333b8b-4021-4b12-af68-fa35f9777053" />
