### PR TITLE
Duplicate recompilation fixed for java files

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4522,6 +4522,17 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 debug("Java source class file modified: " + fileChanged.getName()
                         + ". Adding to list for processing.");
                 modifiedClasses.add(fileChanged);
+
+                if (!recompileJavaSources.isEmpty()) {
+                    int currentMessages = countApplicationUpdatedMessages();
+                    if (currentMessages > numApplicationUpdatedMessages) {
+                        debug("Liberty hot reload detected (CWWKZ0003I), clearing recompileJavaSources list to prevent duplicate recompilation");
+                        debug("Files that will not be recompiled: " + recompileJavaSources);
+                        recompileJavaSources.clear();
+                        // Also clear related flags
+                        triggerJavaSourceRecompile = false;
+                    }
+                }
             } else if (changeType == ChangeType.DELETE) {
                 debug("Java source class deleted: " + fileChanged.getName() + ". Adding to list for processing.");
                 modifiedClasses.remove(fileChanged); // remove if class file is already stored in list

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4529,8 +4529,6 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                         debug("Liberty hot reload detected (CWWKZ0003I), clearing recompileJavaSources list to prevent duplicate recompilation");
                         debug("Files that will not be recompiled: " + recompileJavaSources);
                         recompileJavaSources.clear();
-                        // Also clear related flags
-                        triggerJavaSourceRecompile = false;
                     }
                 }
             } else if (changeType == ChangeType.DELETE) {


### PR DESCRIPTION
Fixes an issue mentioned in the comments of [Maven:#752](https://github.com/OpenLiberty/ci.maven/issues/752), where the issue was about the processFileChanges() was being called multiple times for the same .properties file when modifying in dev mode, but that is working correctly now, but I found an issue that is processFileChanges() is getting called twice for .class files when we change Java sources in dev mode.

When a .java file changes, the plugin queues it for compilation in the recompileJavaSources list. After a timeout, the plugin compiles the .java file into a .class file. Liberty then detects this .class file change and hot reloads the application.

The problem was that the .java file remained in the recompileJavaSources queue even after being compiled. This caused the plugin to compile the same .java file a second time, creating duplicate work and triggering unnecessary file change events.

The fix detects when Liberty has successfully hot reloaded by checking if the Application Update message count increased. If it has reloaded, we clear the recompileJavaSources list to prevent the plugin from compiling the same .java files again. This eliminates the duplicate compilation thus the processFileChanges() will be called only once.