### PR TITLE
Add a check that a file is in the directory it is supposed to be in

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -5014,8 +5014,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
 
     private File getTargetFile(File fileChanged, File srcDir, File targetDir, String targetFileName)
             throws IOException {
-        String relPath = fileChanged.getCanonicalPath().substring(
-                fileChanged.getCanonicalPath().indexOf(srcDir.getCanonicalPath()) + srcDir.getCanonicalPath().length());
+        int srcDirIndex = fileChanged.getCanonicalPath().indexOf(srcDir.getCanonicalPath());
+        if (srcDirIndex < 0 ) { // warn plugin developer this input is invalid, should not happen in production
+            new IllegalArgumentException("fileChanged " + fileChanged + " is not in srcDir " + srcDir).printStackTrace();
+        }
+        String relPath = fileChanged.getCanonicalPath().substring(srcDirIndex + srcDir.getCanonicalPath().length());
         if (targetFileName != null) {
             relPath = relPath.substring(0, relPath.indexOf(fileChanged.getName())) + targetFileName;
         }


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1976

This method calculates a path assuming the file is in the directory passed in. If it is not there then there is an off-by-one error and the plugin may go ahead and silently copy the file to the incorrect location. 

Add an assertion when an invalid parameter is passed. Just print a traceback to the log to prompt the plugin developer to fix the bug. Should not happen in production but if it does the user can open an issue but otherwise keep working.