### PR TITLE
Added support for passing annotation processor paths to the Java compiler

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -47,6 +47,11 @@ public class JavaCompilerOptions {
     private String encoding;
 
     /**
+     * Annotation processor path
+     */
+    private String annotationProcessorPath;
+
+    /**
      * Get list of options that can be passed to the compiler.
      * Options with values are represented as multiple strings in the list
      *  e.g. "-source" and "1.8"
@@ -62,6 +67,7 @@ public class JavaCompilerOptions {
         addStringOption(options, "-target", target);
         addStringOption(options, "--release", release);
         addStringOption(options, "-encoding", encoding);
+        addStringOption(options, "-processorpath", annotationProcessorPath);
         return options;
     }
 
@@ -110,6 +116,14 @@ public class JavaCompilerOptions {
 
     public void setEncoding(String encoding) {
         this.encoding = encoding;
+    }
+
+    public String getAnnotationProcessorPath() {
+        return annotationProcessorPath;
+    }
+
+    public void setAnnotationProcessorPath(String annotationProcessorPath) {
+        this.annotationProcessorPath = annotationProcessorPath;
     }
 
 }

--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020.
+ * (C) Copyright IBM Corporation 2020, 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -52,6 +52,11 @@ public class JavaCompilerOptions {
     private String annotationProcessorPath;
 
     /**
+     * Annotation processors (comma-separated list of processor class names)
+     */
+    private String annotationProcessors;
+
+    /**
      * Get list of options that can be passed to the compiler.
      * Options with values are represented as multiple strings in the list
      *  e.g. "-source" and "1.8"
@@ -68,6 +73,7 @@ public class JavaCompilerOptions {
         addStringOption(options, "--release", release);
         addStringOption(options, "-encoding", encoding);
         addStringOption(options, "-processorpath", annotationProcessorPath);
+        addStringOption(options, "-processor", annotationProcessors);
         return options;
     }
 
@@ -124,6 +130,14 @@ public class JavaCompilerOptions {
 
     public void setAnnotationProcessorPath(String annotationProcessorPath) {
         this.annotationProcessorPath = annotationProcessorPath;
+    }
+
+    public String getAnnotationProcessors() {
+        return annotationProcessors;
+    }
+
+    public void setAnnotationProcessors(String annotationProcessors) {
+        this.annotationProcessors = annotationProcessors;
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -34,16 +34,15 @@ public class JavaCompilerOptionsTest {
         jco.setEncoding("UTF-8");
         
         List<String> result = jco.getOptions();
-        int i = 0;
-        assertTrue(result.get(i++).equals("-source"));
-        assertTrue(result.get(i++).equals("9"));
-        assertTrue(result.get(i++).equals("-target"));
-        assertTrue(result.get(i++).equals("1.8"));
-        assertTrue(result.get(i++).equals("--release"));
-        assertTrue(result.get(i++).equals("10"));
-        assertTrue(result.get(i++).equals("-encoding"));
-        assertTrue(result.get(i++).equals("UTF-8"));
-        assertEquals(i, result.size());
+        assertEquals(8, result.size());
+        assertTrue(result.contains("-source"));
+        assertTrue(result.contains("9"));
+        assertTrue(result.contains("-target"));
+        assertTrue(result.contains("1.8"));
+        assertTrue(result.contains("--release"));
+        assertTrue(result.contains("10"));
+        assertTrue(result.contains("-encoding"));
+        assertTrue(result.contains("UTF-8"));
     }
     
     @Test
@@ -62,9 +61,9 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(3, result.size());
-        assertTrue(result.get(0).equals("-nowarn"));
-        assertTrue(result.get(1).equals("-source"));
-        assertTrue(result.get(2).equals("10"));
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-source"));
+        assertTrue(result.contains("10"));
     }
 
     @Test
@@ -74,9 +73,9 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(3, result.size());
-        assertTrue(result.get(0).equals("-nowarn"));
-        assertTrue(result.get(1).equals("-target"));
-        assertTrue(result.get(2).equals("10"));
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-target"));
+        assertTrue(result.contains("10"));
     }
 
     @Test
@@ -86,9 +85,9 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(3, result.size());
-        assertTrue(result.get(0).equals("-nowarn"));
-        assertTrue(result.get(1).equals("--release"));
-        assertTrue(result.get(2).equals("10"));
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("--release"));
+        assertTrue(result.contains("10"));
     }
 
     @Test
@@ -98,9 +97,9 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(3, result.size());
-        assertTrue(result.get(0).equals("-nowarn"));
-        assertTrue(result.get(1).equals("-encoding"));
-        assertTrue(result.get(2).equals("UTF-8"));
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-encoding"));
+        assertTrue(result.contains("UTF-8"));
     }
 
     @Test
@@ -110,9 +109,9 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(3, result.size());
-        assertTrue(result.get(0).equals("-nowarn"));
-        assertTrue(result.get(1).equals("-processorpath"));
-        assertTrue(result.get(2).equals("/path/to/lombok.jar:/path/to/mapstruct.jar"));
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-processorpath"));
+        assertTrue(result.contains("/path/to/lombok.jar:/path/to/mapstruct.jar"));
     }
 
     @Test
@@ -124,15 +123,13 @@ public class JavaCompilerOptionsTest {
 
         List<String> result = jco.getOptions();
         assertEquals(7, result.size());
-        int i = 0;
-        assertTrue(result.get(i++).equals("-nowarn"));
-        assertTrue(result.get(i++).equals("--release"));
-        assertTrue(result.get(i++).equals("17"));
-        assertTrue(result.get(i++).equals("-encoding"));
-        assertTrue(result.get(i++).equals("UTF-8"));
-        assertTrue(result.get(i++).equals("-processorpath"));
-        assertTrue(result.get(i++).equals("/path/to/lombok.jar"));
-        assertEquals(i, result.size());
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("--release"));
+        assertTrue(result.contains("17"));
+        assertTrue(result.contains("-encoding"));
+        assertTrue(result.contains("UTF-8"));
+        assertTrue(result.contains("-processorpath"));
+        assertTrue(result.contains("/path/to/lombok.jar"));
     }
 
     @Test
@@ -153,6 +150,53 @@ public class JavaCompilerOptionsTest {
         List<String> result = jco.getOptions();
         assertEquals(1, result.size());
         assertTrue(result.get(0).equals("-nowarn"));
+    }
+
+    @Test
+    public void testAnnotationProcessors() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessors("lombok.AnnotationProcessor,org.mapstruct.ap.MappingProcessor");
+
+        List<String> result = jco.getOptions();
+        assertEquals(3, result.size());
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-processor"));
+        assertTrue(result.contains("lombok.AnnotationProcessor,org.mapstruct.ap.MappingProcessor"));
+    }
+
+    @Test
+    public void testAnnotationProcessorsWithPath() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessorPath("/path/to/lombok.jar");
+        jco.setAnnotationProcessors("lombok.AnnotationProcessor");
+
+        List<String> result = jco.getOptions();
+        assertEquals(5, result.size());
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-processorpath"));
+        assertTrue(result.contains("/path/to/lombok.jar"));
+        assertTrue(result.contains("-processor"));
+        assertTrue(result.contains("lombok.AnnotationProcessor"));
+    }
+
+    @Test
+    public void testAnnotationProcessorsNull() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessors(null);
+
+        List<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.contains("-nowarn"));
+    }
+
+    @Test
+    public void testAnnotationProcessorsEmpty() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessors("");
+
+        List<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.contains("-nowarn"));
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -103,4 +103,56 @@ public class JavaCompilerOptionsTest {
         assertTrue(result.get(2).equals("UTF-8"));
     }
 
+    @Test
+    public void testAnnotationProcessorPath() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessorPath("/path/to/lombok.jar:/path/to/mapstruct.jar");
+
+        List<String> result = jco.getOptions();
+        assertEquals(3, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+        assertTrue(result.get(1).equals("-processorpath"));
+        assertTrue(result.get(2).equals("/path/to/lombok.jar:/path/to/mapstruct.jar"));
+    }
+
+    @Test
+    public void testAnnotationProcessorPathWithOtherOptions() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setRelease("17");
+        jco.setEncoding("UTF-8");
+        jco.setAnnotationProcessorPath("/path/to/lombok.jar");
+
+        List<String> result = jco.getOptions();
+        assertEquals(7, result.size());
+        int i = 0;
+        assertTrue(result.get(i++).equals("-nowarn"));
+        assertTrue(result.get(i++).equals("--release"));
+        assertTrue(result.get(i++).equals("17"));
+        assertTrue(result.get(i++).equals("-encoding"));
+        assertTrue(result.get(i++).equals("UTF-8"));
+        assertTrue(result.get(i++).equals("-processorpath"));
+        assertTrue(result.get(i++).equals("/path/to/lombok.jar"));
+        assertEquals(i, result.size());
+    }
+
+    @Test
+    public void testAnnotationProcessorPathNull() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessorPath(null);
+
+        List<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+    }
+
+    @Test
+    public void testAnnotationProcessorPathEmpty() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        jco.setAnnotationProcessorPath("");
+
+        List<String> result = jco.getOptions();
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).equals("-nowarn"));
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/2021

Added support for passing annotation processor paths to the Java compiler via the -processorpath option. This enables annotation processors (Eg: Lombok) to run during compilation in dev mode.