### PR TITLE
Added compiler arguments support to JavaCompilerOptions

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptions.java
@@ -57,6 +57,11 @@ public class JavaCompilerOptions {
     private String annotationProcessors;
 
     /**
+     * Additional compiler arguments from maven-compiler-plugin's compilerArgs configuration.
+     */
+    private List<String> compilerArgs;
+
+    /**
      * Get list of options that can be passed to the compiler.
      * Options with values are represented as multiple strings in the list
      *  e.g. "-source" and "1.8"
@@ -74,6 +79,12 @@ public class JavaCompilerOptions {
         addStringOption(options, "-encoding", encoding);
         addStringOption(options, "-processorpath", annotationProcessorPath);
         addStringOption(options, "-processor", annotationProcessors);
+        
+        // Add compiler arguments from <compilerArgs> configuration
+        if (compilerArgs != null && !compilerArgs.isEmpty()) {
+            options.addAll(compilerArgs);
+        }
+        
         return options;
     }
 
@@ -138,6 +149,14 @@ public class JavaCompilerOptions {
 
     public void setAnnotationProcessors(String annotationProcessors) {
         this.annotationProcessors = annotationProcessors;
+    }
+
+    public List<String> getCompilerArgs() {
+        return compilerArgs;
+    }
+
+    public void setCompilerArgs(List<String> compilerArgs) {
+        this.compilerArgs = compilerArgs;
     }
 
 }

--- a/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
+++ b/src/test/java/io/openliberty/tools/common/plugins/util/JavaCompilerOptionsTest.java
@@ -199,4 +199,19 @@ public class JavaCompilerOptionsTest {
         assertTrue(result.contains("-nowarn"));
     }
 
+    @Test
+    public void testCompilerArgs() throws Exception {
+        JavaCompilerOptions jco = new JavaCompilerOptions();
+        List<String> args = new java.util.ArrayList<>();
+        args.add("-parameters");
+        args.add("-Xlint:unchecked");
+        jco.setCompilerArgs(args);
+
+        List<String> result = jco.getOptions();
+        assertEquals(3, result.size());
+        assertTrue(result.contains("-nowarn"));
+        assertTrue(result.contains("-parameters"));
+        assertTrue(result.contains("-Xlint:unchecked"));
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/2044

Added support for compiler arguments in JavaCompilerOptions by introducing a compilerArgs field with getter/setter methods and updating the getOptions() method to include these arguments in the returned list. This enables build tools to pass arbitrary/custom javac compiler arguments through to the Java compiler during hot reload compilation.