### PR TITLE
Detect files to ignore in generate features temp dir

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4514,8 +4514,11 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
         } else if ((directory.startsWith(configPath)
                 || directory.startsWith(gfTmpDirPath))
                 && !isGeneratedConfigFile(fileChanged, configDirectory, serverDirectory)) {
-            // configuration file or generate-features.xml in temp directory
-            processConfigFileChange(fileChanged, changeType, executor, numApplicationUpdatedMessages, false);
+            // configuration file or generated-features.xml in temp directory (do not handle other files in temp dir.)
+            if (directory.startsWith(configPath) || fileChanged.getName().equals(FeatureGeneratorUtil.GENERATED_FEATURES_FILE_NAME)) {
+                // special case: install features copies all the config files to gfTmpDir. Process only the generated-features.xml.
+                processConfigFileChange(fileChanged, changeType, executor, numApplicationUpdatedMessages, false);
+            }
         } else if (bootstrapPropertiesFileParent != null
                    && directory.equals(bootstrapPropertiesFileParent.getCanonicalFile().toPath())
                    && fileChanged.getCanonicalPath().endsWith(bootstrapPropertiesFile.getName())) {

--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -4512,13 +4512,13 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
             // server will load new properties
             processConfigFileChange(fileChanged, changeType, executor, numApplicationUpdatedMessages, true);
         } else if ((directory.startsWith(configPath)
-                || directory.startsWith(gfTmpDirPath))
+                || (directory.startsWith(gfTmpDirPath)
+                       && fileChanged.getName().equals(FeatureGeneratorUtil.GENERATED_FEATURES_FILE_NAME)))
                 && !isGeneratedConfigFile(fileChanged, configDirectory, serverDirectory)) {
-            // configuration file or generated-features.xml in temp directory (do not handle other files in temp dir.)
-            if (directory.startsWith(configPath) || fileChanged.getName().equals(FeatureGeneratorUtil.GENERATED_FEATURES_FILE_NAME)) {
-                // special case: install features copies all the config files to gfTmpDir. Process only the generated-features.xml.
-                processConfigFileChange(fileChanged, changeType, executor, numApplicationUpdatedMessages, false);
-            }
+            // configuration files or generated-features.xml in temp directory
+            // Do not handle other files in temp dir. since install features method copies all the config files to gfTmpDir.
+            // Exclude bootstrap and server.env which were generated.
+            processConfigFileChange(fileChanged, changeType, executor, numApplicationUpdatedMessages, false);
         } else if (bootstrapPropertiesFileParent != null
                    && directory.equals(bootstrapPropertiesFileParent.getCanonicalFile().toPath())
                    && fileChanged.getCanonicalPath().endsWith(bootstrapPropertiesFile.getName())) {


### PR DESCRIPTION
The original comment suggests we only expect to see changes to `generated-features.xml` in the temp dir. Add code to enforce this so we do not process other files that are copied there by necessity during ~install~ generate features. 

Fixes: https://github.com/OpenLiberty/ci.maven/issues/2046