### PR TITLE
Fixed the race condition: print dev mode ready message after WatchService registration

### DIFF
--- a/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
+++ b/src/main/java/io/openliberty/tools/common/plugins/util/DevUtil.java
@@ -2548,8 +2548,8 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                     // it's available
                     inputUnavailable.wait(500);
                 }
-                printDevModeMessages(inputUnavailable.get(), firstStartup);
-                firstStartup = false;
+                // firstStartup is false by the time this is called after initial startup.
+                printDevModeMessages(inputUnavailable.get(), false);
             } catch (InterruptedException e) {
                 debug("Interrupted while waiting to determine whether input can be read", e);
             } catch (PluginExecutionException pe) {
@@ -3175,6 +3175,17 @@ public abstract class DevUtil extends AbstractContainerSupportUtil {
                 for (File f : propertyFilesMap.keySet()) {
                     registerSingleFile(f, executor);
                 }
+            }
+
+            if (firstStartup) {
+                synchronized (inputUnavailable) {
+                    try {
+                        printDevModeMessages(inputUnavailable.get(), true);
+                    } catch (PluginExecutionException pe) {
+                        error(pe.getMessage());
+                    }
+                }
+                firstStartup = false;
             }
 
             initWatchLoop();


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/2070

PR Ci.Maven: https://github.com/OpenLiberty/ci.maven/pull/2073
PR Ci.Gradle: https://github.com/OpenLiberty/ci.gradle/pull/1095

In DevUtil.watchFiles(), the "Liberty is running in dev mode." startup banner is now printed after all source, test, config, and resource directories have been registered with the WatchService, but before initWatchLoop() enters the event poll. Previously the banner was emitted by runHotkeyReaderThread() in the callers (ci.maven's DevMojo, ci.gradle's DevTask) before watchFiles() was even called, meaning any file change made immediately after that message by a test or a user could race ahead of the watcher and be silently dropped with no recompile triggered. Moving the print into watchFiles() and checking it in with the existing firstStartup flag makes the ready message a reliable synchronisation point: once a user or test sees it, the WatchService is fully set up and guaranteed to detect changes. The runHotkeyReaderThread() post test run re print path is unchanged.

